### PR TITLE
Add default value for request body.

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ function requestbody(opts) {
   opts.formidable = 'formidable' in opts ? opts.formidable : {};
 
   return function *(next){
-    var body;
+    var body = {};
     if (this.is('json'))  {
       body = yield buddy.json(this, {encoding: opts.encoding, limit: opts.jsonLimit});
     }


### PR DESCRIPTION
Since i was using some middleware with `koa-body` sometimes request body is undefined and then will cause some error `Cannot read property xx of undefined` with the requset.body. So i was thinking add a default value `{}` is a good idea to solved the issue like this.
If not maybe i need add a middleware like 

```
function *(next) {
     this.request.body = this.request.body || {}
    yield next
}
```
