### PR TITLE
Don't parse request bodies on GET, HEAD, DELETE requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,14 +41,19 @@ function requestbody(opts) {
 
   return function *(next){
     var body = {};
-    if (this.is('json'))  {
-      body = yield buddy.json(this, {encoding: opts.encoding, limit: opts.jsonLimit});
-    }
-    else if (this.is('urlencoded')) {
-      body = yield buddy.form(this, {encoding: opts.encoding, limit: opts.formLimit});
-    }
-    else if (opts.multipart && this.is('multipart')) {
-      body = yield formy(this, opts.formidable);
+    // GET, HEAD, and DELETE requests have no defined semantics for the request body
+    // (http://tools.ietf.org/html/draft-ietf-httpbis-p2-semantics-19#section-6.3)
+    // so don't parse the body in those cases.
+    if (["GET", "HEAD", "DELETE"].indexOf(this.method.toUpperCase()) === -1) {
+      if (this.is('json'))  {
+        body = yield buddy.json(this, {encoding: opts.encoding, limit: opts.jsonLimit});
+      }
+      else if (this.is('urlencoded')) {
+        body = yield buddy.form(this, {encoding: opts.encoding, limit: opts.formLimit});
+      }
+      else if (opts.multipart && this.is('multipart')) {
+        body = yield formy(this, opts.formidable);
+      }
     }
 
     if (opts.patchNode) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koa-body",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A koa body parser middleware. Support multipart, urlencoded and json request bodies.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
If request bodies are sent for GET, HEAD or DELETE requests but aren't valid, we will currently crash when trying to parse them. According to HTTP 1.1 (http://tools.ietf.org/html/draft-ietf-httpbis-p2-semantics-19#section-6.3) request bodies for GET, HEAD and DELETE requests don't have defined semantics, so we don't have to parse them -- we can be tolerant of our inputs here.