### PR TITLE
Expose strict mode option

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ console.log('curl -i http://localhost:3131/ -d "name=test"');
 - `encoding` **{String}** Sets encoding for incoming form fields, default `utf-8`
 - `multipart` **{Boolean}** Parse multipart bodies, default `false`
 - `formidable` **{Object}** Options to pass to the formidable multipart parser
+- `strict` **{Boolean}** If enabled, don't parse GET, HEAD, DELETE requests, default `true`
+
+## A note about strict mode
+> see [http://tools.ietf.org/html/draft-ietf-httpbis-p2-semantics-19#section-6.3](http://tools.ietf.org/html/draft-ietf-httpbis-p2-semantics-19#section-6.3)
+- GET, HEAD, and DELETE requests have no defined semantics for the request body, but this doesn't mean they may not be valid in certain use cases.
+- koa-body is strict by default
 
 ## Some options for formidable
 > See [node-formidable](https://github.com/felixge/node-formidable) for a full list of options

--- a/index.js
+++ b/index.js
@@ -38,13 +38,12 @@ function requestbody(opts) {
   opts.jsonLimit = 'jsonLimit' in opts ? opts.jsonLimit : '1mb';
   opts.formLimit = 'formLimit' in opts ? opts.formLimit : '56kb';
   opts.formidable = 'formidable' in opts ? opts.formidable : {};
+  opts.strict = 'strict' in opts ? opts.strict : true;
 
   return function *(next){
     var body = {};
-    // GET, HEAD, and DELETE requests have no defined semantics for the request body
-    // (http://tools.ietf.org/html/draft-ietf-httpbis-p2-semantics-19#section-6.3)
-    // so don't parse the body in those cases.
-    if (["GET", "HEAD", "DELETE"].indexOf(this.method.toUpperCase()) === -1) {
+    // so don't parse the body in strict mode
+    if (!opts.strict || ["GET", "HEAD", "DELETE"].indexOf(this.method.toUpperCase()) === -1) {
       if (this.is('json'))  {
         body = yield buddy.json(this, {encoding: opts.encoding, limit: opts.jsonLimit});
       }

--- a/package.json
+++ b/package.json
@@ -44,10 +44,11 @@
   },
   "devDependencies": {
     "koa": "*",
-    "koa-router": "*",
     "koa-resource-router": "*",
-    "multiline": "*",
+    "koa-router": "*",
+    "lodash": "^3.3.1",
     "mocha": "*",
+    "multiline": "*",
     "should": "*",
     "supertest": "*"
   },


### PR DESCRIPTION
The recent change #11 caused some issues with people who are passing a request body in with their DELETE, GET, HEAD requests (ref: #12).

Though generally a sign of bad practice to pass a request body with these http methods, it may be desirable in certain situations.

This change exposes a `strict` mode option, which is by default enabled, that can be turned off.