### PR TITLE
Update formidable version

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "co-body": "*",
     "extend": "1.3.0",
-    "formidable": "1.0.15"
+    "formidable": "1.0.17"
   },
   "devDependencies": {
     "koa": "*",


### PR DESCRIPTION
This is due to a deprecated method call which has now been fixed in formidable 1.0.17