### PR TITLE
Also parse text request

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ function requestbody(opts) {
   opts.jsonLimit = 'jsonLimit' in opts ? opts.jsonLimit : '1mb';
   opts.formLimit = 'formLimit' in opts ? opts.formLimit : '56kb';
   opts.formidable = 'formidable' in opts ? opts.formidable : {};
-  opts.textLimit = 'textLimit' in opts ? opts.formLimit : '56kb';
+  opts.textLimit = 'textLimit' in opts ? opts.textLimit : '56kb';
   opts.strict = 'strict' in opts ? opts.strict : true;
 
   return function *(next){

--- a/index.js
+++ b/index.js
@@ -38,6 +38,7 @@ function requestbody(opts) {
   opts.jsonLimit = 'jsonLimit' in opts ? opts.jsonLimit : '1mb';
   opts.formLimit = 'formLimit' in opts ? opts.formLimit : '56kb';
   opts.formidable = 'formidable' in opts ? opts.formidable : {};
+  opts.textLimit = 'textLimit' in opts ? opts.formLimit : '56kb';
   opts.strict = 'strict' in opts ? opts.strict : true;
 
   return function *(next){
@@ -49,6 +50,9 @@ function requestbody(opts) {
       }
       else if (this.is('urlencoded')) {
         body = yield buddy.form(this, {encoding: opts.encoding, limit: opts.formLimit});
+      }
+      else if (this.is('text')) {
+        body = yield buddy.text(this, {encoding: opts.encoding, limit: opts.textLimit});
       }
       else if (opts.multipart && this.is('multipart')) {
         body = yield formy(this, opts.formidable);

--- a/test/index.js
+++ b/test/index.js
@@ -549,4 +549,30 @@ describe('koa-body', function () {
         .expect(200, {})
         .end(done);
     });
+
+  /**
+   * TEXT LIMIT
+   */
+  it('should request 413 Payload Too Large, because of `textLimit`', function (done) {
+    var app = koa();
+    var usersResource = new Resource('users', {
+      // POST /users
+      create: function *(next) {
+        //suggestions for handling?
+        //what if we want to make body more user-friendly?
+      }
+    });
+
+
+    app.use(koaBody({textLimit: 10 /*bytes*/}));
+    app.use(usersResource.middleware());
+
+    request(http.createServer(app.callback()))
+      .post('/users')
+      .type('text')
+      .send('String longer than 10 bytes...')
+      .expect(413, 'Payload Too Large')
+      .expect('content-length', 17)
+      .end(done);
+  });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -227,6 +227,38 @@ describe('koa-body', function () {
   });
 
 
+  /**
+   * TEXT request body
+   */
+  it('should recieve `text` request bodies', function (done) {
+    var app = koa();
+    var usersResource = new Resource('users', {
+      // POST /users
+      create: function *(next) {
+        database.users.push(this.request.body);
+        this.status = 201;
+        this.body = this.request.body;
+      }
+    });
+
+
+    app.use(koaBody({multipart: true}));
+    app.use(usersResource.middleware());
+
+    request(http.createServer(app.callback()))
+      .post('/users')
+      .type('text')
+      .send('plain text')
+      .expect(201)
+      .end(function(err, res) {
+        if (err) return done(err);
+
+        var requested = database.users.pop();
+        res.text.should.equal(requested);
+
+        done();
+      });
+  });
 
   describe('strict mode', function (done) {
     var app = null;


### PR DESCRIPTION
Since `co-body` has good support for type `text`, I suggest we support `text` as well.