### PR TITLE
link to mocha

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ console.log('curl -i http://localhost:3131/users -d "name=test"');
 
 
 ## Tests
-> As usual - `npm test` **or** if you have [mocha][mocha-url] globally - `mocha --harmony-generators`.
+> As usual - `npm test` **or** if you have [mocha](https://mochajs.org) globally - `mocha --harmony-generators`.
 
 ```
 $ npm test


### PR DESCRIPTION
![url-with-issue](https://cloud.githubusercontent.com/assets/1933203/12311016/18add41a-ba09-11e5-8ac2-2403d7591022.png)

Previous version of the link had a reference to mocha-url in a second set of square brackets but mocha-url was not defined anywhere else in the document. Updated link is simpler and does not use a reference.