### PR TITLE
Add flags for all upload types

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ console.log('curl -i http://localhost:3131/users -d "name=test"');
 - `textLimit` **{String|Integer}** The byte (if integer) limit of the text body, default `56kb`
 - `encoding` **{String}** Sets encoding for incoming form fields, default `utf-8`
 - `multipart` **{Boolean}** Parse multipart bodies, default `false`
+- `urlencoded` **{Boolean}** Parse urlencoded bodies, default `true`
+- `text` **{Boolean}** Parse text bodies, default `true`
+- `json` **{Boolean}** Parse json bodies, default `true`
 - `formidable` **{Object}** Options to pass to the formidable multipart parser
 - `strict` **{Boolean}** If enabled, don't parse GET, HEAD, DELETE requests, default `true`
 

--- a/index.js
+++ b/index.js
@@ -34,6 +34,9 @@ function requestbody(opts) {
   opts.patchNode = 'patchNode' in opts ? opts.patchNode : false;
   opts.patchKoa  = 'patchKoa'  in opts ? opts.patchKoa  : true;
   opts.multipart = 'multipart' in opts ? opts.multipart : false;
+  opts.urlencoded = 'urlencoded' in opts ? opts.urlencoded : true;
+  opts.json = 'json' in opts ? opts.json : true;
+  opts.text = 'text' in opts ? opts.text : true;
   opts.encoding  = 'encoding'  in opts ? opts.encoding  : 'utf-8';
   opts.jsonLimit = 'jsonLimit' in opts ? opts.jsonLimit : '1mb';
   opts.formLimit = 'formLimit' in opts ? opts.formLimit : '56kb';
@@ -45,13 +48,13 @@ function requestbody(opts) {
     var body = {};
     // so don't parse the body in strict mode
     if (!opts.strict || ["GET", "HEAD", "DELETE"].indexOf(this.method.toUpperCase()) === -1) {
-      if (this.is('json'))  {
+      if (opts.json && this.is('json'))  {
         body = yield buddy.json(this, {encoding: opts.encoding, limit: opts.jsonLimit});
       }
-      else if (this.is('urlencoded')) {
+      else if (opts.urlencoded && this.is('urlencoded')) {
         body = yield buddy.form(this, {encoding: opts.encoding, limit: opts.formLimit});
       }
-      else if (this.is('text')) {
+      else if (opts.text && this.is('text')) {
         body = yield buddy.text(this, {encoding: opts.encoding, limit: opts.textLimit});
       }
       else if (opts.multipart && this.is('multipart')) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koa-body",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "A koa body parser middleware. Support multipart, urlencoded and json request bodies.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Parsing url encoded file uploads does not work properly. Could not figure out the exact issue so I had to switch to another parser for that part. 

I added flags for enable/disable all types of parsing. This adds some more flexibility to the package.

Nice work.
Thanks