### PR TITLE
add queryString for qs

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ function requestbody(opts) {
   opts.encoding = 'encoding' in opts ? opts.encoding : 'utf-8';
   opts.jsonLimit = 'jsonLimit' in opts ? opts.jsonLimit : '1mb';
   opts.formLimit = 'formLimit' in opts ? opts.formLimit : '56kb';
+  opts.queryString = 'queryString' in opts ? opts.queryString : null;
   opts.formidable = 'formidable' in opts ? opts.formidable : {};
   opts.textLimit = 'textLimit' in opts ? opts.textLimit : '56kb';
   opts.strict = 'strict' in opts ? opts.strict : true;
@@ -58,7 +59,8 @@ function requestbody(opts) {
         } else if (opts.urlencoded && ctx.is('urlencoded')) {
           bodyPromise = buddy.form(ctx, {
             encoding: opts.encoding,
-            limit: opts.formLimit
+            limit: opts.formLimit,
+            queryString: opts.queryString
           });
         } else if (opts.text && ctx.is('text')) {
           bodyPromise = buddy.text(ctx, {


### PR DESCRIPTION
here only encoding and limit

in co-body->form used qs module
return opts.qs.parse(str, opts.queryString);

qs will also limit specifying indices in an array to a maximum index of 20. Any array members with an index of greater than 20 will instead be converted to an object with the index as the key