### PR TITLE
Move koa from dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,10 +39,10 @@
   ],
   "dependencies": {
     "co-body": "*",
-    "formidable": "1.0.17",
-    "koa": "^2.0.0"
+    "formidable": "1.0.17"
   },
   "devDependencies": {
+    "koa": "^2.0.0",
     "koa-router": "^7.0.1",
     "lodash": "^3.3.1",
     "mocha": "*",


### PR DESCRIPTION
Koa is used only in tests so it can go into devDependencies so that this middleware doesn't pull it in when installed in projects.