### PR TITLE
Upgrade dependency formidable to 1.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   ],
   "dependencies": {
     "co-body": "*",
-    "formidable": "1.0.17"
+    "formidable": "1.1.1"
   },
   "devDependencies": {
     "koa-router": "^7.0.1",


### PR DESCRIPTION
Solves the os.tmpDir() deprecation issue