### PR TITLE
Allow formLimit, jsonLimit, and textLimit to take functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,12 @@ console.log('curl -i http://localhost:3000/users -d "name=test"');
 
 - `patchNode` **{Boolean}** Patch request body to Node's `ctx.req`, default `false`
 - `patchKoa` **{Boolean}** Patch request body to Koa's `ctx.request`, default `true`
-- `jsonLimit` **{String|Integer}** The byte (if integer) limit of the JSON body, default `1mb`
-- `formLimit` **{String|Integer}** The byte (if integer) limit of the form body, default `56kb`
-- `textLimit` **{String|Integer}** The byte (if integer) limit of the text body, default `56kb`
+- `jsonLimit` **{String|Integer|Function}** The byte (if integer) limit of the JSON body, default `1mb`
+  - If this is a `function`, it should take `ctx` as an argument.
+- `formLimit` **{String|Integer|Function}** The byte (if integer) limit of the form body, default `56kb`
+  - If this is a `function`, it should take `ctx` as an argument.
+- `textLimit` **{String|Integer|Function}** The byte (if integer) limit of the text body, default `56kb`
+  - If this is a `function`, it should take `ctx` as an argument.
 - `encoding` **{String}** Sets encoding for incoming form fields, default `utf-8`
 - `multipart` **{Boolean}** Parse multipart bodies, default `false`
 - `urlencoded` **{Boolean}** Parse urlencoded bodies, default `true`

--- a/README.md
+++ b/README.md
@@ -90,11 +90,11 @@ console.log('curl -i http://localhost:3000/users -d "name=test"');
 - `patchNode` **{Boolean}** Patch request body to Node's `ctx.req`, default `false`
 - `patchKoa` **{Boolean}** Patch request body to Koa's `ctx.request`, default `true`
 - `jsonLimit` **{String|Integer|Function}** The byte (if integer) limit of the JSON body, default `1mb`
-  - If this is a `function`, it should take `ctx` as an argument.
+  - If this is a `function`, it takes `ctx` as the first argument.
 - `formLimit` **{String|Integer|Function}** The byte (if integer) limit of the form body, default `56kb`
-  - If this is a `function`, it should take `ctx` as an argument.
+  - If this is a `function`, it takes `ctx` as the first argument.
 - `textLimit` **{String|Integer|Function}** The byte (if integer) limit of the text body, default `56kb`
-  - If this is a `function`, it should take `ctx` as an argument.
+  - If this is a `function`, it takes `ctx` as the first argument.
 - `encoding` **{String}** Sets encoding for incoming form fields, default `utf-8`
 - `multipart` **{Boolean}** Parse multipart bodies, default `false`
 - `urlencoded` **{Boolean}** Parse urlencoded bodies, default `true`

--- a/index.js
+++ b/index.js
@@ -51,21 +51,28 @@ function requestbody(opts) {
     // so don't parse the body in strict mode
     if (!opts.strict || ["GET", "HEAD", "DELETE"].indexOf(ctx.method.toUpperCase()) === -1) {
       try {
+        var limit;
         if (opts.json && ctx.is('json')) {
+          limit = typeof opts.jsonLimit === 'function' ? opts.jsonLimit(ctx) : opts.jsonLimit;
+
           bodyPromise = buddy.json(ctx, {
             encoding: opts.encoding,
-            limit: opts.jsonLimit
+            limit: limit
           });
         } else if (opts.urlencoded && ctx.is('urlencoded')) {
+          limit = typeof opts.formLimit === 'function' ? opts.formLimit(ctx) : opts.formLimit;
+          
           bodyPromise = buddy.form(ctx, {
             encoding: opts.encoding,
-            limit: opts.formLimit,
+            limit: limit,
             queryString: opts.queryString
           });
         } else if (opts.text && ctx.is('text')) {
+          limit = typeof opts.textLimit === 'function' ? opts.textLimit(ctx) : opts.textLimit;
+          
           bodyPromise = buddy.text(ctx, {
             encoding: opts.encoding,
-            limit: opts.textLimit
+            limit: limit
           });
         } else if (opts.multipart && ctx.is('multipart')) {
           bodyPromise = formy(ctx, opts.formidable);

--- a/test/index.js
+++ b/test/index.js
@@ -401,12 +401,38 @@ describe('koa-body', () => {
       .end(done);
   });
 
+  it('should take a function for `formLimit`',  (done) => {
+    app.use(koaBody({ formLimit: () => 10 /*bytes*/ }));
+    app.use(router.routes());
+
+    request(http.createServer(app.callback()))
+      .post('/users')
+      .type('application/x-www-form-urlencoded')
+      .send('user=www-form-urlencoded')
+      .expect(413, 'Payload Too Large')
+      .expect('content-length', '17')
+      .end(done);
+  });
+
 
   /**
    * JSON LIMIT
    */
   it('should request 413 Payload Too Large, because of `jsonLimit`',  (done) => {
     app.use(koaBody({ jsonLimit: 10 /*bytes*/ }));
+    app.use(router.routes());
+
+    request(http.createServer(app.callback()))
+      .post('/users')
+      .type('application/json')
+      .send({ name: 'some-long-name-for-limit' })
+      .expect(413, 'Payload Too Large')
+      .expect('content-length', '17')
+      .end(done);
+  });
+
+  it('should take a function for `jsonLimit`',  (done) => {
+    app.use(koaBody({ jsonLimit: () => 10 /*bytes*/ }));
     app.use(router.routes());
 
     request(http.createServer(app.callback()))
@@ -436,6 +462,19 @@ describe('koa-body', () => {
    */
   it('should request 413 Payload Too Large, because of `textLimit`',  (done) =>  {
     app.use(koaBody({ textLimit: 10 /*bytes*/ }));
+    app.use(router.routes());
+
+    request(http.createServer(app.callback()))
+      .post('/users')
+      .type('text')
+      .send('String longer than 10 bytes...')
+      .expect(413, 'Payload Too Large')
+      .expect('content-length', '17')
+      .end(done);
+  });
+
+  it('should take a function for `textLimit`',  (done) =>  {
+    app.use(koaBody({ textLimit: () => 10 /*bytes*/ }));
     app.use(router.routes());
 
     request(http.createServer(app.callback()))


### PR DESCRIPTION
This would be pretty useful for allowing different endpoints to have different max data limits. If a function is specified, it takes `ctx` as an argument.