### PR TITLE
Fix promise error handling order

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,20 +80,20 @@ function requestbody(opts) {
     }
 
     bodyPromise = bodyPromise || Promise.resolve({});
-    return bodyPromise.then(function(body) {
+    return bodyPromise.catch(function(parsingError) {
+      if (typeof opts.onError === 'function') {
+        opts.onError(parsingError, ctx);
+      } else {
+        throw parsingError;
+      }
+      return next();
+    })
+    .then(function(body) {
       if (opts.patchNode) {
         ctx.req.body = body;
       }
       if (opts.patchKoa) {
         ctx.request.body = body;
-      }
-      return next();
-    })
-    .catch(function(parsingError) {
-      if (typeof opts.onError === 'function') {
-        opts.onError(parsingError, ctx);
-      } else {
-        throw parsingError;
       }
       return next();
     })


### PR DESCRIPTION
As it is currently, any errors that are thrown in any middleware after the body parser are caught and passed through the `onError` config option. This pull request fixes the order so that only body parsing errors are passed to the `onError` function, not all errors from other middleware.