### PR TITLE
Update files property of package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,15 +28,11 @@
     "form"
   ],
   "files": [
-    ".gitignore",
-    ".npmignore",
-    ".travis.yml",
     "LICENSE",
-    "Makefile",
     "README.md",
-    "example.js",
     "index.js",
-    "test.js"
+    "index.d.ts",
+    "package.json"
   ],
   "dependencies": {
     "co-body": "^5.1.1",


### PR DESCRIPTION
`index.d.ts` wasn't making it through to the npm package because of an outdated `"files":` property in the `package.json`.

I've removed all unnecessary and non canonical files which don't affect the correct working of the package. Things like: tests, examples, CI leftovers, .npmignore, makefile etc. and added the missing `index.d.ts`.