### PR TITLE
Adds `jsonStrict` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ console.log('curl -i http://localhost:3000/users -d "name=test"');
 - `urlencoded` **{Boolean}** Parse urlencoded bodies, default `true`
 - `text` **{Boolean}** Parse text bodies, default `true`
 - `json` **{Boolean}** Parse json bodies, default `true`
+- `jsonStrict` **{Boolean}** Toggles co-body strict mode; if set to true - only parses arrays or objects, default `true`
 - `formidable` **{Object}** Options to pass to the formidable multipart parser
 - `onError` **{Function}** Custom error handle, if throw an error, you can customize the response - onError(error, context), default will throw
 - `strict` **{Boolean}** If enabled, don't parse GET, HEAD, DELETE requests, default `true`

--- a/index.d.ts
+++ b/index.d.ts
@@ -108,6 +108,11 @@ declare namespace koaBody {
         json?: boolean;
 
         /**
+         * Toggles co-body strict mode; if true, only parses arrays or objects, default true
+         */
+        jsonStrict?: boolean;
+
+        /**
          * {Object} Options to pass to the formidable multipart parser
          */
         formidable?: IKoaBodyFormidableOptions;

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@
  * Module dependencies.
  */
 
-var buddy = require('co-body')({strict:false});
+var buddy = require('co-body');
 var forms = require('formidable');
 
 /**
@@ -40,6 +40,7 @@ function requestbody(opts) {
   opts.text = 'text' in opts ? opts.text : true;
   opts.encoding = 'encoding' in opts ? opts.encoding : 'utf-8';
   opts.jsonLimit = 'jsonLimit' in opts ? opts.jsonLimit : '1mb';
+  opts.jsonStrict = 'jsonStrict' in opts ? opts.jsonStrict : true;
   opts.formLimit = 'formLimit' in opts ? opts.formLimit : '56kb';
   opts.queryString = 'queryString' in opts ? opts.queryString : null;
   opts.formidable = 'formidable' in opts ? opts.formidable : {};
@@ -54,7 +55,8 @@ function requestbody(opts) {
         if (opts.json && ctx.is('json')) {
           bodyPromise = buddy.json(ctx, {
             encoding: opts.encoding,
-            limit: opts.jsonLimit
+            limit: opts.jsonLimit,
+            strict: opts.jsonStrict
           });
         } else if (opts.urlencoded && ctx.is('urlencoded')) {
           bodyPromise = buddy.form(ctx, {

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@
  * Module dependencies.
  */
 
-var buddy = require('co-body');
+var buddy = require('co-body')({strict:false});
 var forms = require('formidable');
 
 /**


### PR DESCRIPTION
Adds a jsonStrict option that can be passed to co-body for JSON parsing. By default (true), co-body only allows arrays and objects. This allows us to pass false, which allows for all types (such as string literal, etc.)