### PR TITLE
#75 Use `ctx.request.files` instead of `ctx.request.body.files`

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,14 +90,37 @@ function requestbody(opts) {
     })
     .then(function(body) {
       if (opts.patchNode) {
-        ctx.req.body = body;
+        if(isMultiPart(opts, ctx)) {
+          ctx.req.body.fields = body.fields
+          ctx.req.files = body.files;
+        } else {
+          ctx.req.body = body;
+        }
       }
       if (opts.patchKoa) {
-        ctx.request.body = body;
+        if(isMultiPart(opts, ctx)) {
+          ctx.request.body.fields = body.fields;
+          ctx.request.files = body.files;
+        } else {
+          ctx.request.body = body;
+        }
       }
       return next();
     })
   };
+}
+
+/**
+ * Check If It's multipart request
+ *
+ * @param  {Object} ctx
+ * @param  {Object} opts
+ * @return {Boolean}
+ * @api private
+ */
+
+function isMultiPart(ctx, opts) {
+  return (opts.multipart && ctx.is('multipart'))
 }
 
 /**

--- a/test/index.js
+++ b/test/index.js
@@ -56,13 +56,19 @@ describe('koa-body', () => {
       })
       .post('/users', (ctx, next) => {
         const user = ctx.request.body.fields || ctx.request.body;
+
         if(!user) {
           ctx.status = 400;
           return next();
         }
         database.users.push(user);
         ctx.status = 201;
-        ctx.body = ctx.request.body;
+
+        if(ctx.request.files) {
+          ctx.body = ctx.request.files
+        } else {
+          ctx.body = ctx.request.body
+        }
       })
       .delete('/users/:user', (ctx, next) => {
         const user = ctx.params.user;
@@ -116,6 +122,7 @@ describe('koa-body', () => {
         if (err) return done(err);
 
         var mostRecentUser = _.last(database.users);
+
         res.body.fields.should.have.property('name', mostRecentUser.name);
         res.body.fields.should.have.property('followers', mostRecentUser.followers);
 
@@ -249,7 +256,6 @@ describe('koa-body', () => {
       .expect(201)
       .end( (err, res) => {
         if (err) return done(err);
-
         const mostRecentUser = _.last(database.users);
         res.body.should.have.property('name', mostRecentUser.name);
         res.body.should.have.property('followers', mostRecentUser.followers);


### PR DESCRIPTION
I see a big security problem of putting file objects in `ctx.request.body.files` from https://github.com/dlau/koa-body/issues/75. 

so I changed it to put file objects in `ctx.request.files` instead of `ctx.request.body.files`, because there's a couple issues at the current version. 

1. if there's `files` field and multipart file included in request at the same time, there'd be a conflict.
2. if somebody specifies **files** field to request, somebody could view any contents on the server by specifying the path on **files** field.  details in the [issue](https://github.com/dlau/koa-body/issues/75).