### PR TITLE
Make request parsing accept the returnRawBody option inorder to return the raw string

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ console.log('curl -i http://localhost:3000/users -d "name=test"');
 - `text` **{Boolean}** Parse text bodies, default `true`
 - `json` **{Boolean}** Parse json bodies, default `true`
 - `jsonStrict` **{Boolean}** Toggles co-body strict mode; if set to true - only parses arrays or objects, default `true`
-- `returnRawBody` **{Boolean}** Toggles co-body returnRawBody option; if set to true, for requests of type `'application/x-www-form-urlencoded`, the object returned will be `{ parsed: parsed value,  raw: raw body}`, where the key `parsed` will contain the `parsed` and the key `raw` will contain the raw urlencoded form parameters string, default `true`
+- `returnRawBody` **{Boolean}** Toggles co-body returnRawBody option; if set to true, for requests of type `'application/x-www-form-urlencoded`, the object returned will be `{ parsed: parsed value,  raw: raw body}`, where the key `parsed` will contain the `parsed` and the key `raw` will contain the raw urlencoded form parameters string, default `false`
 - `formidable` **{Object}** Options to pass to the formidable multipart parser
 - `onError` **{Function}** Custom error handle, if throw an error, you can customize the response - onError(error, context), default will throw
 - `strict` **{Boolean}** If enabled, don't parse GET, HEAD, DELETE requests, default `true`

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ console.log('curl -i http://localhost:3000/users -d "name=test"');
 - `text` **{Boolean}** Parse text bodies, default `true`
 - `json` **{Boolean}** Parse json bodies, default `true`
 - `jsonStrict` **{Boolean}** Toggles co-body strict mode; if set to true - only parses arrays or objects, default `true`
+- `returnRawBody` **{Boolean}** Toggles co-body returnRawBody option; if set to true, for requests of type ``, the object returned will  `{ parsed: parsed value,  raw: raw body}`, default `true`
 - `formidable` **{Object}** Options to pass to the formidable multipart parser
 - `onError` **{Function}** Custom error handle, if throw an error, you can customize the response - onError(error, context), default will throw
 - `strict` **{Boolean}** If enabled, don't parse GET, HEAD, DELETE requests, default `true`

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ console.log('curl -i http://localhost:3000/users -d "name=test"');
 - `text` **{Boolean}** Parse text bodies, default `true`
 - `json` **{Boolean}** Parse json bodies, default `true`
 - `jsonStrict` **{Boolean}** Toggles co-body strict mode; if set to true - only parses arrays or objects, default `true`
-- `returnRawBody` **{Boolean}** Toggles co-body returnRawBody option; if set to true, for requests of type ``, the object returned will  `{ parsed: parsed value,  raw: raw body}`, default `true`
+- `returnRawBody` **{Boolean}** Toggles co-body returnRawBody option; if set to true, for requests of type `'application/x-www-form-urlencoded`, the object returned will be `{ parsed: parsed value,  raw: raw body}`, where the key `parsed` will contain the `parsed` and the key `raw` will contain the raw urlencoded form parameters string, default `true`
 - `formidable` **{Object}** Options to pass to the formidable multipart parser
 - `onError` **{Function}** Custom error handle, if throw an error, you can customize the response - onError(error, context), default will throw
 - `strict` **{Boolean}** If enabled, don't parse GET, HEAD, DELETE requests, default `true`

--- a/index.d.ts
+++ b/index.d.ts
@@ -112,6 +112,13 @@ declare namespace koaBody {
          * Toggles co-body strict mode; if true, only parses arrays or objects, default true
          */
         jsonStrict?: boolean;
+        
+        /**
+         * Toggles co-body returnRawBody mode; if true, 
+         * the return value of co-body will be an object with two properties: { parsed: parsed value,  raw: raw body}.
+         * default true
+         */
+        returnRawBody?: boolean;
 
         /**
          * {Object} Options to pass to the formidable multipart parser

--- a/index.js
+++ b/index.js
@@ -44,6 +44,7 @@ function requestbody(opts) {
   opts.formLimit = 'formLimit' in opts ? opts.formLimit : '56kb';
   opts.queryString = 'queryString' in opts ? opts.queryString : null;
   opts.formidable = 'formidable' in opts ? opts.formidable : {};
+  opts.returnRawBody = 'returnRawBody' in opts ? opts.returnRawBody : true
   opts.textLimit = 'textLimit' in opts ? opts.textLimit : '56kb';
   opts.strict = 'strict' in opts ? opts.strict : true;
 
@@ -62,7 +63,8 @@ function requestbody(opts) {
           bodyPromise = buddy.form(ctx, {
             encoding: opts.encoding,
             limit: opts.formLimit,
-            queryString: opts.queryString
+            queryString: opts.queryString,
+            returnRawBody: opts.returnRawBody
           });
         } else if (opts.text && ctx.is('text')) {
           bodyPromise = buddy.text(ctx, {

--- a/index.js
+++ b/index.js
@@ -57,7 +57,8 @@ function requestbody(opts) {
           bodyPromise = buddy.json(ctx, {
             encoding: opts.encoding,
             limit: opts.jsonLimit,
-            strict: opts.jsonStrict
+            strict: opts.jsonStrict,
+            returnRawBody: opts.returnRawBody
           });
         } else if (opts.urlencoded && ctx.is('urlencoded')) {
           bodyPromise = buddy.form(ctx, {
@@ -69,7 +70,8 @@ function requestbody(opts) {
         } else if (opts.text && ctx.is('text')) {
           bodyPromise = buddy.text(ctx, {
             encoding: opts.encoding,
-            limit: opts.textLimit
+            limit: opts.textLimit,
+            returnRawBody: opts.returnRawBody
           });
         } else if (opts.multipart && ctx.is('multipart')) {
           bodyPromise = formy(ctx, opts.formidable);

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ function requestbody(opts) {
   opts.formLimit = 'formLimit' in opts ? opts.formLimit : '56kb';
   opts.queryString = 'queryString' in opts ? opts.queryString : null;
   opts.formidable = 'formidable' in opts ? opts.formidable : {};
-  opts.returnRawBody = 'returnRawBody' in opts ? opts.returnRawBody : true
+  opts.returnRawBody = 'returnRawBody' in opts ? opts.returnRawBody : false
   opts.textLimit = 'textLimit' in opts ? opts.textLimit : '56kb';
   opts.strict = 'strict' in opts ? opts.strict : true;
 

--- a/test/index.js
+++ b/test/index.js
@@ -264,6 +264,37 @@ describe('koa-body', () => {
       });
   });
 
+  /**
+   * URLENCODED request body with returnRawBody
+   */
+
+  it('should recieve `urlencoded` request bodies with the returnRawBody option',  (done) => {
+    app.use(koaBody({ multipart: true, returnRawBody: true}));
+    app.use(router.routes());
+
+    request(http.createServer(app.callback()))
+      .post('/users')
+      .type('application/x-www-form-urlencoded')
+      .send({
+        name: 'Test',
+        followers: '97'
+      })
+      .expect(201)
+      .end( (err, res) => {
+        if (err) return done(err);
+
+        const mostRecentUser = database.users[database.users.length - 1];
+        res.body.user.should.have.properties('parsed');
+        res.body.user.should.have.properties('raw');
+        res.body.user.parsed.should.have.properties({ name: 'Test', followers: '97' });
+        res.body.user.parsed.should.have.properties(mostRecentUser.parsed);
+        res.body.user.raw.should.equal('name=Test&followers=97')
+        done();
+      });
+  });
+
+
+
 
   /**
    * TEXT request body


### PR DESCRIPTION
This PR adds an option for the `koa-body` middleware to accept the `returnRawBody` parameter, that  can then be passed on to the `co-body` library so that on parsing urlencoded parameters, one has control over whether to return the original `raw` urlencoded string alongside the parsed urlencoded string.

Implementation in co-body: [link (code)](https://github.com/cojs/co-body/blob/db6041c27ce9a6b280aa49c88d82e3ee0da6a844/lib/form.js#L43)

`co-body` [documentation] (https://github.com/cojs/co-body)


### Use Case:
Consider the case of slack's  [api] (https://api.slack.com/docs/verifying-requests-from-slack) when verifying hmac requests, part of the hashed data inlcudes the raw urlencoded string. There was previously no way of getting this with `koa-body`
