### PR TITLE
Fix empty body breaking includeUnparsed

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,9 +101,9 @@ function requestbody(opts) {
           ctx.req.body = body.fields;
           ctx.req.files = body.files;
         } else if (opts.includeUnparsed) {
-          ctx.req.body = body.parsed;
+          ctx.req.body = body.parsed || {};
           if (! ctx.is('text')) {
-            ctx.request.body[symbolUnparsed] = body.raw;  
+            ctx.req.body[symbolUnparsed] = body.raw;  
           }
         } else {
           ctx.req.body = body;
@@ -114,7 +114,7 @@ function requestbody(opts) {
           ctx.request.body = body.fields;
           ctx.request.files = body.files;
         } else if (opts.includeUnparsed) {
-          ctx.request.body = body.parsed;
+          ctx.request.body = body.parsed || {};
           if (! ctx.is('text')) {
             ctx.request.body[symbolUnparsed] = body.raw;
           }

--- a/test/index.js
+++ b/test/index.js
@@ -167,7 +167,7 @@ describe('koa-body', () => {
         res.body.user.names.should.be.an.Array().and.have.lengthOf(2);
         res.body.user.names[0].should.equal('John');
         res.body.user.names[1].should.equal('Paul');
-        res.body._files.firstField.should.be.an.Object;
+        res.body._files.firstField.should.be.an.Object();
         res.body._files.firstField.name.should.equal('package.json');
         should(fs.statSync(res.body._files.firstField.path)).be.ok;
         fs.unlinkSync(res.body._files.firstField.path);
@@ -230,9 +230,9 @@ describe('koa-body', () => {
       .end( (err, res) => {
         if (err) return done(err);
 
-        res.body._files.firstField.should.be.an.Object;
+        res.body._files.firstField.should.be.an.Object();
         res.body._files.firstField.name.should.equal('backage.json');
-        should(fs.statSync(res.body._files.firstField.path)).be.ok;
+        should(fs.statSync(res.body._files.firstField.path)).be.ok();
         fs.unlinkSync(res.body._files.firstField.path);
 
         done();
@@ -299,11 +299,11 @@ describe('koa-body', () => {
           assert(requestSpy.calledOnce, 'Spy for /echo_body not called');
           const req = requestSpy.firstCall.args[0].request;
 
-          req.body.should.be.null;
+          req.body.should.not.be.Undefined();
           res.body.should.have.properties({});
 
-          req.body[unparsed].should.not.be.undefined;
-          req.body[unparsed].should.be.a.String;
+          req.body[unparsed].should.not.be.Undefined();
+          req.body[unparsed].should.be.a.String();
           req.body[unparsed].should.have.length(0);
 
           done();
@@ -330,8 +330,8 @@ describe('koa-body', () => {
 
           assert(requestSpy.calledOnce, 'Spy for /users not called');
           const req = requestSpy.firstCall.args[0].request;
-          req.body[unparsed].should.not.be.undefined;
-          req.body[unparsed].should.be.a.String;
+          req.body[unparsed].should.not.be.Undefined();
+          req.body[unparsed].should.be.a.String();
           req.body[unparsed].should.equal('name=Test&followers=97');
           
           res.body.user.should.have.properties({ name: 'Test', followers: '97' });
@@ -358,8 +358,8 @@ describe('koa-body', () => {
 
           assert(requestSpy.calledOnce, 'Spy for /echo_body not called');
           const req = requestSpy.firstCall.args[0].request;
-          req.body[unparsed].should.not.be.undefined;
-          req.body[unparsed].should.be.a.String;
+          req.body[unparsed].should.not.be.Undefined();
+          req.body[unparsed].should.be.a.String();
           req.body[unparsed].should.equal(JSON.stringify({
             hello: 'world',
             number: 42
@@ -386,14 +386,14 @@ describe('koa-body', () => {
 
           assert(requestSpy.calledOnce, 'Spy for /echo_body not called');
           const req = requestSpy.firstCall.args[0].request;
-          req.body.should.equal('plain text content');
+          should(req.body).equal('plain text content');
 
           // Raw text requests are still just text
           assert.equal(req.body[unparsed], undefined);
          
           // Text response is just text
-          res.body.should.have.properties({});
-          res.text.should.equal('plain text content');
+          should(res.body).have.properties({});
+          should(res.text).equal('plain text content');
 
           done();
         });


### PR DESCRIPTION
Fall back to an empty object if there's no parsed body when `includeUnparsed` is `true`.

Relative to #129, I couldn't get `koa-body` to fail in the testing suite with an empty POST request, but if the server doesn't deny routes based on their method, I could then reproduce the bug, (ie. Send a GET request to a POST route). The report is valid enough though, as some downstream configurations of koa might have `app.use(router.routes())` without also using `app.use(router.allowedMethods())`. In these cases, koa will run the middleware stack first then find a 404 after - from what I can tell it'd be these requests that caused `koa-body#includeUnparsed` to fail as described. 

The fix I'm proposing here is to fall back to an empty object if there's no parsed body. This way downstream code still has a valid (albeit empty) object with the Symbol applied. 