### PR TITLE
Explicitly specify `Koa.Middleware` params in typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -152,6 +152,6 @@ declare namespace koaBody {
     }
 }
 
-declare function koaBody (options?: koaBody.IKoaBodyOptions): Koa.Middleware;
+declare function koaBody (options?: koaBody.IKoaBodyOptions): Koa.Middleware<{}, {}>;
 
 export = koaBody;


### PR DESCRIPTION
This way we explicitly state `koa-body` doesn't add anything to Koa's `ctx`
or `ctx.state`.

It's useful because with those changes it won't erase `ctx.state` type,
converting it into `any`. Like, if we have some middleware:

```ts
import Koa from 'koa';

type FooCtx = { foo: string };
const someMiddleware: Koa.Middleware<FooCtx, {}> = (ctx, next) => {
    ctx.state.foo = "foo";
}
```

Before the changes in this PR it would be:

```ts
const app = new Koa<{}, {}>()
    .use(someMiddleware)
    .use(koaBody())
// app is Koa<any, {}>
```

After the changes in this PR:

```ts
const app = new Koa<{}, {}>()
  .use(someMiddleware)
  .use(koaBody())
// app is Koa<FooCtx, {}>
```