### PR TITLE
Test Refactor

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,19 @@
+module.exports = {
+  env: {
+    commonjs: true,
+    es6: true,
+    node: true,
+    mocha: true
+  },
+  extends: 'airbnb-base',
+  globals: {
+    Atomics: 'readonly',
+    SharedArrayBuffer: 'readonly',
+  },
+  parserOptions: {
+    ecmaVersion: 2018,
+  },
+  rules: {
+    'consistent-return': 0
+  },
+};

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 npm-debug.log
 yarn.lock
 package-lock.json
+coverage/

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,14 @@ node_js:
   - "8"
   - "10"
   - "11"
+matrix:
+  include:
+    - node_js: '10'
+      env: COVERAGE=true # c8 only works on Node.js 10+
+script: |
+  if [ -z "$COVERAGE" ]
+  then
+    npm test
+  else
+    npm run coverage
+  fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
-  - "6"
   - "8"
   - "10"
+  - "11"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 5.0.0 (Unreleased)
+
+### Breaking Changes
+- drops support for Node.js 6
+
+### Non-Breaking Changes
+- TODO
+
 ## 4.1.0
 - adds `parsedMethods` option to specify which request methods will be parsed
 - deprecates `strict` option, which will be removed in koa-body 5.0.0

--- a/README.md
+++ b/README.md
@@ -123,10 +123,8 @@ Some applications require crytopgraphic verification of request bodies, for exam
 ## Changelog
 Please see the [Changelog](./CHANGELOG.md) for a summary of changes.
 
-## Tests
-```
-$ npm test
-```
+## Tests/Coverage
+See the [testing readme](./test/README.md).
 
 ## License
 The MIT License, 2014 [Charlike Mike Reagent](https://github.com/tunnckoCore) ([@tunnckoCore](https://twitter.com/tunnckoCore)) and [Daryl Lau](https://github.com/dlau) ([@daryllau](https://twitter.com/daryllau))

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "types": "./index.d.ts",
   "scripts": {
     "test": "mocha && eslint ./test",
+    "coverage": "c8 --check-coverage --lines 85 --functions 100 --branches 70 mocha",
     "examples-multer": "node examples/multer.js",
     "examples-koa-router": "node examples/koa-router.js"
   },
@@ -42,6 +43,7 @@
   },
   "devDependencies": {
     "@types/koa": "^2.0.39",
+    "c8": "3.4.0",
     "eslint": "5.15.1",
     "eslint-config-airbnb-base": "13.1.0",
     "eslint-plugin-import": "2.16.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "test": "mocha && eslint ./test",
     "coverage": "c8 --check-coverage --lines 85 --functions 100 --branches 70 mocha",
+    "coverage:html" : "npm run coverage && c8 report --reporter=html && echo 'Coverage report generated, open coverage/index.html in your browser'",
     "examples-multer": "node examples/multer.js",
     "examples-koa-router": "node examples/koa-router.js"
   },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "test": "mocha && eslint ./test",
     "coverage": "c8 --check-coverage --lines 85 --functions 100 --branches 70 mocha",
-    "coverage:html" : "npm run coverage && c8 report --reporter=html && echo 'Coverage report generated, open coverage/index.html in your browser'",
+    "coverage:html": "npm run coverage && c8 report --reporter=html && echo 'Coverage report generated, open coverage/index.html in your browser'",
     "examples-multer": "node examples/multer.js",
     "examples-koa-router": "node examples/koa-router.js"
   },
@@ -45,13 +45,13 @@
   "devDependencies": {
     "@types/koa": "^2.0.39",
     "c8": "3.4.0",
+    "chai": "4.2.0",
     "eslint": "5.15.1",
     "eslint-config-airbnb-base": "13.1.0",
     "eslint-plugin-import": "2.16.0",
     "koa": "^2.0.0",
     "koa-router": "^7.0.1",
     "mocha": "6.0.2",
-    "should": "13.2.1",
     "sinon": "^7.2.2",
     "supertest": "3.4.2"
   },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "types": "./index.d.ts",
   "scripts": {
-    "test": "mocha",
+    "test": "mocha && eslint ./test",
     "examples-multer": "node examples/multer.js",
     "examples-koa-router": "node examples/koa-router.js"
   },
@@ -42,12 +42,15 @@
   },
   "devDependencies": {
     "@types/koa": "^2.0.39",
+    "eslint": "5.15.1",
+    "eslint-config-airbnb-base": "13.1.0",
+    "eslint-plugin-import": "2.16.0",
     "koa": "^2.0.0",
     "koa-router": "^7.0.1",
     "mocha": "5.2.0",
     "should": "13.2.1",
     "sinon": "^7.2.2",
-    "supertest": "3.1.0"
+    "supertest": "3.4.2"
   },
   "contributors": [
     {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "eslint-plugin-import": "2.16.0",
     "koa": "^2.0.0",
     "koa-router": "^7.0.1",
-    "mocha": "5.2.0",
+    "mocha": "6.0.2",
     "should": "13.2.1",
     "sinon": "^7.2.2",
     "supertest": "3.4.2"

--- a/test/README.md
+++ b/test/README.md
@@ -11,8 +11,7 @@ To run coverage, you must be using [c8's supported version](https://github.com/b
 
 To get an HTML coverage report, run the following commands:
 ```sh
-npm run coverage
-./node_modules/.bin/c8 report --reporter=html
+npm run coverage:html
 ```
 
 CI will fail if a line, function, and branch coverage percentage is not met. This is set in `package.json` in the `coverage` script.

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,18 @@
+# koa-body Test Info
+
+Running tests:
+```sh
+npm install
+npm test
+```
+
+## Coverage
+To run coverage, you must be using [c8's supported version](https://github.com/bcoe/c8#supported-nodejs-versions) of Node.js, v10.12.0+.
+
+To get an HTML coverage report, run the following commands:
+```sh
+npm run coverage
+./node_modules/.bin/c8 report --reporter=html
+```
+
+CI will fail if a line, function, and branch coverage percentage is not met. This is set in `package.json` in the `coverage` script.

--- a/test/index.js
+++ b/test/index.js
@@ -98,20 +98,19 @@ describe('koa-body', async () => {
     app.use(koaBody({ multipart: true }));
     app.use(router.routes());
 
-    return request(http.createServer(app.callback()))
+    const res = await request(http.createServer(app.callback()))
       .post('/users')
       .field('name', 'daryl')
       .field('followers', 30)
-      .expect(201)
-      .then((res) => {
-        const mostRecentUser = database.users[database.users.length - 1];
+      .expect(201);
 
-        res.body.user.should.have.property('name', mostRecentUser.name);
-        res.body.user.should.have.property('followers', mostRecentUser.followers);
+    const mostRecentUser = database.users[database.users.length - 1];
 
-        res.body.user.should.have.property('name', 'daryl');
-        res.body.user.should.have.property('followers', '30');
-      });
+    res.body.user.should.have.property('name', mostRecentUser.name);
+    res.body.user.should.have.property('followers', mostRecentUser.followers);
+
+    res.body.user.should.have.property('name', 'daryl');
+    res.body.user.should.have.property('followers', '30');
   });
 
 
@@ -127,7 +126,7 @@ describe('koa-body', async () => {
     }));
     app.use(router.routes());
 
-    return request(http.createServer(app.callback()))
+    const res = await request(http.createServer(app.callback()))
       .post('/users')
       .type('multipart/form-data')
       .field('names', 'John')
@@ -138,46 +137,45 @@ describe('koa-body', async () => {
       .attach('thirdField', 'LICENSE')
       .attach('thirdField', 'README.md')
       .attach('thirdField', 'package.json')
-      .expect(201)
-      .then((res) => {
-        res.body.user.names.should.be.an.Array().and.have.lengthOf(2);
-        res.body.user.names[0].should.equal('John');
-        res.body.user.names[1].should.equal('Paul');
-        res.body._files.firstField.should.be.an.Object();
-        res.body._files.firstField.name.should.equal('package.json');
-        should(fs.statSync(res.body._files.firstField.path)).be.ok();
-        fs.unlinkSync(res.body._files.firstField.path);
+      .expect(201);
 
-        res.body._files.secondField.should.be.an.Array().and.have.lengthOf(2);
-        res.body._files.secondField.should.containDeep([{
-          name: 'index.js',
-        }]);
-        res.body._files.secondField.should.containDeep([{
-          name: 'package.json',
-        }]);
-        should(fs.statSync(res.body._files.secondField[0].path)).be.ok();
-        should(fs.statSync(res.body._files.secondField[1].path)).be.ok();
-        fs.unlinkSync(res.body._files.secondField[0].path);
-        fs.unlinkSync(res.body._files.secondField[1].path);
+    res.body.user.names.should.be.an.Array().and.have.lengthOf(2);
+    res.body.user.names[0].should.equal('John');
+    res.body.user.names[1].should.equal('Paul');
+    res.body._files.firstField.should.be.an.Object();
+    res.body._files.firstField.name.should.equal('package.json');
+    should(fs.statSync(res.body._files.firstField.path)).be.ok();
+    fs.unlinkSync(res.body._files.firstField.path);
 
-        res.body._files.thirdField.should.be.an.Array().and.have.lengthOf(3);
+    res.body._files.secondField.should.be.an.Array().and.have.lengthOf(2);
+    res.body._files.secondField.should.containDeep([{
+      name: 'index.js',
+    }]);
+    res.body._files.secondField.should.containDeep([{
+      name: 'package.json',
+    }]);
+    should(fs.statSync(res.body._files.secondField[0].path)).be.ok();
+    should(fs.statSync(res.body._files.secondField[1].path)).be.ok();
+    fs.unlinkSync(res.body._files.secondField[0].path);
+    fs.unlinkSync(res.body._files.secondField[1].path);
 
-        res.body._files.thirdField.should.containDeep([{
-          name: 'LICENSE',
-        }]);
-        res.body._files.thirdField.should.containDeep([{
-          name: 'README.md',
-        }]);
-        res.body._files.thirdField.should.containDeep([{
-          name: 'package.json',
-        }]);
-        should(fs.statSync(res.body._files.thirdField[0].path)).be.ok();
-        fs.unlinkSync(res.body._files.thirdField[0].path);
-        should(fs.statSync(res.body._files.thirdField[1].path)).be.ok();
-        fs.unlinkSync(res.body._files.thirdField[1].path);
-        should(fs.statSync(res.body._files.thirdField[2].path)).be.ok();
-        fs.unlinkSync(res.body._files.thirdField[2].path);
-      });
+    res.body._files.thirdField.should.be.an.Array().and.have.lengthOf(3);
+
+    res.body._files.thirdField.should.containDeep([{
+      name: 'LICENSE',
+    }]);
+    res.body._files.thirdField.should.containDeep([{
+      name: 'README.md',
+    }]);
+    res.body._files.thirdField.should.containDeep([{
+      name: 'package.json',
+    }]);
+    should(fs.statSync(res.body._files.thirdField[0].path)).be.ok();
+    fs.unlinkSync(res.body._files.thirdField[0].path);
+    should(fs.statSync(res.body._files.thirdField[1].path)).be.ok();
+    fs.unlinkSync(res.body._files.thirdField[1].path);
+    should(fs.statSync(res.body._files.thirdField[2].path)).be.ok();
+    fs.unlinkSync(res.body._files.thirdField[2].path);
   });
 
   it('can transform file names in multipart requests', async () => {
@@ -195,19 +193,17 @@ describe('koa-body', async () => {
     }));
     app.use(router.routes());
 
-    return request(http.createServer(app.callback()))
+    const res = await request(http.createServer(app.callback()))
       .post('/users')
       .type('multipart/form-data')
       .field('names', 'John')
       .field('names', 'Paul')
       .attach('firstField', 'package.json')
-      .expect(201)
-      .then((res) => {
-        res.body._files.firstField.should.be.an.Object();
-        res.body._files.firstField.name.should.equal('backage.json');
-        should(fs.statSync(res.body._files.firstField.path)).be.ok();
-        fs.unlinkSync(res.body._files.firstField.path);
-      });
+      .expect(201);
+    res.body._files.firstField.should.be.an.Object();
+    res.body._files.firstField.name.should.equal('backage.json');
+    should(fs.statSync(res.body._files.firstField.path)).be.ok();
+    fs.unlinkSync(res.body._files.firstField.path);
   });
 
 
@@ -218,20 +214,18 @@ describe('koa-body', async () => {
     app.use(koaBody({ multipart: true }));
     app.use(router.routes());
 
-    return request(http.createServer(app.callback()))
+    const res = await request(http.createServer(app.callback()))
       .post('/users')
       .type('application/x-www-form-urlencoded')
       .send({
         name: 'example',
         followers: '41',
       })
-      .expect(201)
-      .then((res) => {
-        const mostRecentUser = database.users[database.users.length - 1];
+      .expect(201);
+    const mostRecentUser = database.users[database.users.length - 1];
 
-        res.body.user.should.have.properties(mostRecentUser);
-        res.body.user.should.have.properties({ name: 'example', followers: '41' });
-      });
+    res.body.user.should.have.properties(mostRecentUser);
+    res.body.user.should.have.properties({ name: 'example', followers: '41' });
   });
 
   /**
@@ -241,15 +235,13 @@ describe('koa-body', async () => {
     app.use(koaBody({ multipart: true }));
     app.use(router.routes());
 
-    return request(http.createServer(app.callback()))
+    const res = await request(http.createServer(app.callback()))
       .post('/echo_body')
       .type('text')
       .send('plain text')
-      .expect(200)
-      .then((res) => {
-        res.type.should.equal('text/plain');
-        res.text.should.equal('plain text');
-      });
+      .expect(200);
+    res.type.should.equal('text/plain');
+    res.text.should.equal('plain text');
   });
 
   describe('strict mode', async () => {
@@ -344,17 +336,15 @@ describe('koa-body', async () => {
       app.use(koaBody({ strict: false }));
       app.use(router.routes());
 
-      return request(http.createServer(app.callback()))
+      const res = await request(http.createServer(app.callback()))
         .post('/users')
         .type('application/json')
         .send({
           name: 'json',
           followers: '313',
         })
-        .expect(201)
-        .then((res) => {
-          res.body.user.should.have.properties({ followers: '313', name: 'json' });
-        });
+        .expect(201);
+      res.body.user.should.have.properties({ followers: '313', name: 'json' });
     });
   });
 
@@ -368,14 +358,11 @@ describe('koa-body', async () => {
         name: 'foo',
         followers: 111,
       });
-      return request(http.createServer(app.callback()))
+      response = await request(http.createServer(app.callback()))
         .get('/users')
         .type('application/json')
         .send({ name: 'foo' })
-        .expect(200)
-        .then((res) => {
-          response = res;
-        });
+        .expect(200);
     });
 
     it('should parse the response body', async () => {

--- a/test/index.js
+++ b/test/index.js
@@ -85,7 +85,7 @@ describe('koa-body', async () => {
     app.use(koaBody());
     app.use(router.routes());
 
-    return request(http.createServer(app.callback()))
+    await request(http.createServer(app.callback()))
       .get('/users')
       .expect(200, database);
   });
@@ -254,7 +254,7 @@ describe('koa-body', async () => {
       app.use(koaBody({ strict: true }));
       app.use(router.routes());
 
-      return request(http.createServer(app.callback()))
+      await request(http.createServer(app.callback()))
         .delete('/users/charlike')
         .type('application/x-www-form-urlencoded')
         .send({ multi: true })
@@ -268,14 +268,13 @@ describe('koa-body', async () => {
       app.use(koaBody({ strict: false }));
       app.use(router.routes());
 
-      return request(http.createServer(app.callback()))
+      await request(http.createServer(app.callback()))
         .delete('/users/charlike')
         .type('application/x-www-form-urlencoded')
         .send({ multi: true })
-        .expect(204)
-        .then(() => {
-          should.equal(database.users.find(element => element.name === 'charlike'), undefined);
-        });
+        .expect(204);
+
+      should.equal(database.users.find(element => element.name === 'charlike'), undefined);
     });
   });
 
@@ -289,28 +288,26 @@ describe('koa-body', async () => {
       app.use(koaBody({ parsedMethods: ['POST', 'PUT', 'PATCH', 'DELETE'] }));
       app.use(router.routes());
 
-      return request(http.createServer(app.callback()))
+      await request(http.createServer(app.callback()))
         .delete('/users/charlike')
         .type('application/x-www-form-urlencoded')
         .send({ multi: true })
-        .expect(204)
-        .then(() => {
-          should.equal(database.users.find(element => element.name === 'charlike'), undefined);
-        });
+        .expect(204);
+
+      should.equal(database.users.find(element => element.name === 'charlike'), undefined);
     });
 
     it('methods do not get parsed if not declared', async () => {
       app.use(koaBody({ parsedMethods: ['POST', 'PUT', 'PATCH'] }));
       app.use(router.routes());
 
-      return request(http.createServer(app.callback()))
+      await request(http.createServer(app.callback()))
         .delete('/users/charlike')
         .type('application/x-www-form-urlencoded')
         .send({ multi: true })
-        .expect(204)
-        .then(() => {
-          should.notEqual(database.users.find(element => element.name === 'charlike'), undefined);
-        });
+        .expect(204);
+
+      should.notEqual(database.users.find(element => element.name === 'charlike'), undefined);
     });
 
     it('cannot use strict mode and parsedMethods options at the same time', async () => {
@@ -379,7 +376,7 @@ describe('koa-body', async () => {
     app.use(koaBody());
     app.use(router.routes());
 
-    return request(http.createServer(app.callback()))
+    await request(http.createServer(app.callback()))
       .post('/users')
       .send('Hello <b>invalid</b> content type')
       .expect(201);

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,5 @@
 /* eslint-disable no-underscore-dangle */
 
-const assert = require('assert');
 const fs = require('fs');
 const http = require('http');
 const path = require('path');
@@ -269,7 +268,7 @@ describe('koa-body', async () => {
         .send({ multi: true })
         .expect(204)
         .then(() => {
-          assert(database.users.find(element => element.name === 'charlike') !== undefined);
+          should.notEqual(database.users.find(element => element.name === 'charlike'), undefined);
         });
     });
 
@@ -283,7 +282,7 @@ describe('koa-body', async () => {
         .send({ multi: true })
         .expect(204)
         .then(() => {
-          assert(database.users.find(element => element.name === 'charlike') === undefined);
+          should.equal(database.users.find(element => element.name === 'charlike'), undefined);
         });
     });
   });
@@ -304,7 +303,7 @@ describe('koa-body', async () => {
         .send({ multi: true })
         .expect(204)
         .then(() => {
-          assert(database.users.find(element => element.name === 'charlike') === undefined);
+          should.equal(database.users.find(element => element.name === 'charlike'), undefined);
         });
     });
 
@@ -318,7 +317,7 @@ describe('koa-body', async () => {
         .send({ multi: true })
         .expect(204)
         .then(() => {
-          assert(database.users.find(element => element.name === 'charlike') !== undefined);
+          should.notEqual(database.users.find(element => element.name === 'charlike'), undefined);
         });
     });
 
@@ -333,7 +332,7 @@ describe('koa-body', async () => {
         err = _err;
       }
 
-      assert(err && err.message === 'Cannot use strict and parsedMethods options at the same time.');
+      should.equal(err.message, 'Cannot use strict and parsedMethods options at the same time.');
     });
   });
 

--- a/test/limits.js
+++ b/test/limits.js
@@ -15,7 +15,7 @@ describe('limits', () => {
     app.use(koaBody({ formLimit: 10 /* bytes */ }));
     app.use(router.routes());
 
-    return request(http.createServer(app.callback()))
+    await request(http.createServer(app.callback()))
       .post('/')
       .type('application/x-www-form-urlencoded')
       .send('user=www-form-urlencoded')
@@ -30,7 +30,7 @@ describe('limits', () => {
     app.use(koaBody({ jsonLimit: 10 /* bytes */ }));
     app.use(router.routes());
 
-    return request(http.createServer(app.callback()))
+    await request(http.createServer(app.callback()))
       .post('/')
       .type('application/json')
       .send({ name: 'some-long-name-for-limit' })
@@ -45,7 +45,7 @@ describe('limits', () => {
     app.use(koaBody({ textLimit: 10 /* bytes */ }));
     app.use(router.routes());
 
-    return request(http.createServer(app.callback()))
+    await request(http.createServer(app.callback()))
       .post('/')
       .type('text')
       .send('String longer than 10 bytes...')

--- a/test/limits.js
+++ b/test/limits.js
@@ -1,0 +1,54 @@
+const http = require('http');
+const Koa = require('koa');
+const request = require('supertest');
+const Router = require('koa-router');
+const koaBody = require('../index');
+
+const ERR_413_STATUSTEXT = 'request entity too large';
+
+describe('limits', () => {
+  it(`hitting formLimit should respond with 413 ${ERR_413_STATUSTEXT}`, async () => {
+    const app = new Koa();
+    const router = Router().post('/users', (ctx) => {
+      ctx.status = 200;
+    });
+    app.use(koaBody({ formLimit: 10 /* bytes */ }));
+    app.use(router.routes());
+
+    return request(http.createServer(app.callback()))
+      .post('/')
+      .type('application/x-www-form-urlencoded')
+      .send('user=www-form-urlencoded')
+      .expect(413, ERR_413_STATUSTEXT);
+  });
+
+  it(`hitting jsonLimit should respond with 413 ${ERR_413_STATUSTEXT}`, async () => {
+    const app = new Koa();
+    const router = Router().post('/users', (ctx) => {
+      ctx.status = 200;
+    });
+    app.use(koaBody({ jsonLimit: 10 /* bytes */ }));
+    app.use(router.routes());
+
+    return request(http.createServer(app.callback()))
+      .post('/')
+      .type('application/json')
+      .send({ name: 'some-long-name-for-limit' })
+      .expect(413, ERR_413_STATUSTEXT);
+  });
+
+  it(`hitting textLimit should respond with a 413 ${ERR_413_STATUSTEXT}`, async () => {
+    const app = new Koa();
+    const router = Router().post('/users', (ctx) => {
+      ctx.status = 200;
+    });
+    app.use(koaBody({ textLimit: 10 /* bytes */ }));
+    app.use(router.routes());
+
+    return request(http.createServer(app.callback()))
+      .post('/')
+      .type('text')
+      .send('String longer than 10 bytes...')
+      .expect(413, ERR_413_STATUSTEXT);
+  });
+});

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,2 +1,0 @@
---reporter spec
---require should

--- a/test/unparsed.js
+++ b/test/unparsed.js
@@ -1,0 +1,120 @@
+const http = require('http');
+const Koa = require('koa');
+const request = require('supertest');
+const Router = require('koa-router');
+const should = require('should');
+const sinon = require('sinon');
+const unparsed = require('../unparsed.js');
+const koaBody = require('../index');
+
+/**
+ * Inclusion of unparsed body when opts.includeUnparsed is true
+ */
+describe('includeUnparsed tests', async () => {
+  let app;
+  let router;
+
+  beforeEach(async () => {
+    app = new Koa();
+    router = Router().post('/echo_body', (ctx) => {
+      ctx.status = 200;
+      ctx.body = ctx.request.body;
+    });
+    app.use(koaBody({ includeUnparsed: true }));
+    app.use(router.routes());
+  });
+
+  it('should not fail when no request body is provided', async () => {
+    const echoRouterLayer = router.stack.find(layer => layer.path === '/echo_body');
+    const requestSpy = sinon.spy(echoRouterLayer.stack, '0');
+
+    return request(http.createServer(app.callback()))
+      .post('/echo_body')
+      .type('application/json')
+      .send(undefined)
+      .expect(200)
+      .then((res) => {
+        should.equal(requestSpy.calledOnce, true, 'Spy for /echo_body not called');
+        const req = requestSpy.firstCall.args[0].request;
+
+        req.body.should.not.be.Undefined();
+        res.body.should.deepEqual({});
+
+        req.body[unparsed].should.not.be.Undefined();
+        req.body[unparsed].should.be.a.String();
+        req.body[unparsed].should.have.length(0);
+      });
+  });
+
+  it('should recieve `urlencoded` request bodies with the `includeUnparsed` option', async () => {
+    const echoRouterLayer = router.stack.find(layer => layer.path === '/echo_body');
+    const requestSpy = sinon.spy(echoRouterLayer.stack, '0');
+
+    return request(http.createServer(app.callback()))
+      .post('/echo_body')
+      .type('application/x-www-form-urlencoded')
+      .send({
+        name: 'Test',
+        followers: '97',
+      })
+      .expect(200)
+      .then((res) => {
+        should.equal(requestSpy.calledOnce, true, 'Spy for /echo_body not called');
+        const req = requestSpy.firstCall.args[0].request;
+        req.body[unparsed].should.not.be.Undefined();
+        req.body[unparsed].should.be.a.String();
+        req.body[unparsed].should.equal('name=Test&followers=97');
+
+        res.body.should.deepEqual({ name: 'Test', followers: '97' });
+      });
+  });
+
+  it('should receive JSON request bodies as strings with the `includeUnparsed` option', async () => {
+    const echoRouterLayer = router.stack.find(layer => layer.path === '/echo_body');
+    const requestSpy = sinon.spy(echoRouterLayer.stack, '0');
+
+    return request(http.createServer(app.callback()))
+      .post('/echo_body')
+      .type('application/json')
+      .send({
+        hello: 'world',
+        number: 42,
+      })
+      .expect(200)
+      .then((res) => {
+        should.equal(requestSpy.calledOnce, true, 'Spy for /echo_body not called');
+        const req = requestSpy.firstCall.args[0].request;
+        req.body[unparsed].should.not.be.Undefined();
+        req.body[unparsed].should.be.a.String();
+        req.body[unparsed].should.equal(JSON.stringify({
+          hello: 'world',
+          number: 42,
+        }));
+
+        res.body.should.deepEqual({ hello: 'world', number: 42 });
+      });
+  });
+
+  it('should receive text as strings with `includeUnparsed` option', async () => {
+    const echoRouterLayer = router.stack.find(layer => layer.path === '/echo_body');
+    const requestSpy = sinon.spy(echoRouterLayer.stack, '0');
+
+    return request(http.createServer(app.callback()))
+      .post('/echo_body')
+      .type('text')
+      .send('plain text content')
+      .expect(200)
+      .then((res) => {
+        should.equal(requestSpy.calledOnce, true, 'Spy for /echo_body not called');
+        const req = requestSpy.firstCall.args[0].request;
+        should(req.body).equal('plain text content');
+
+        // Raw text requests are still just text
+        should.equal(req.body[unparsed], undefined);
+
+        // Text response is just text
+        should(res.body).have.properties({});
+        should(res.text).equal('plain text content');
+      });
+  });
+});

--- a/test/unparsed.js
+++ b/test/unparsed.js
@@ -1,8 +1,8 @@
 const http = require('http');
 const Koa = require('koa');
 const request = require('supertest');
+const { expect } = require('chai');
 const Router = require('koa-router');
-const should = require('should');
 const sinon = require('sinon');
 const unparsed = require('../unparsed.js');
 const koaBody = require('../index');
@@ -34,15 +34,11 @@ describe('includeUnparsed tests', async () => {
       .send(undefined)
       .expect(200);
 
-    should.equal(requestSpy.calledOnce, true, 'Spy for /echo_body not called');
+    expect(requestSpy.calledOnce).to.equal(true, 'Spy for /echo_body not called');
     const req = requestSpy.firstCall.args[0].request;
 
-    req.body.should.not.be.Undefined();
-    res.body.should.deepEqual({});
-
-    req.body[unparsed].should.not.be.Undefined();
-    req.body[unparsed].should.be.a.String();
-    req.body[unparsed].should.have.length(0);
+    expect(res.body).to.eql({});
+    expect(req.body[unparsed]).to.equal('');
   });
 
   it('should recieve `urlencoded` request bodies with the `includeUnparsed` option', async () => {
@@ -58,13 +54,11 @@ describe('includeUnparsed tests', async () => {
       })
       .expect(200);
 
-    should.equal(requestSpy.calledOnce, true, 'Spy for /echo_body not called');
+    expect(requestSpy.calledOnce).to.equal(true, 'Spy for /echo_body not called');
     const req = requestSpy.firstCall.args[0].request;
-    req.body[unparsed].should.not.be.Undefined();
-    req.body[unparsed].should.be.a.String();
-    req.body[unparsed].should.equal('name=Test&followers=97');
+    expect(req.body[unparsed]).to.equal('name=Test&followers=97');
 
-    res.body.should.deepEqual({ name: 'Test', followers: '97' });
+    expect(res.body).to.eql({ name: 'Test', followers: '97' });
   });
 
   it('should receive JSON request bodies as strings with the `includeUnparsed` option', async () => {
@@ -80,16 +74,14 @@ describe('includeUnparsed tests', async () => {
       })
       .expect(200);
 
-    should.equal(requestSpy.calledOnce, true, 'Spy for /echo_body not called');
+    expect(requestSpy.calledOnce).to.equal(true, 'Spy for /echo_body not called');
     const req = requestSpy.firstCall.args[0].request;
-    req.body[unparsed].should.not.be.Undefined();
-    req.body[unparsed].should.be.a.String();
-    req.body[unparsed].should.equal(JSON.stringify({
+    expect(req.body[unparsed]).to.eql(JSON.stringify({
       hello: 'world',
       number: 42,
     }));
 
-    res.body.should.deepEqual({ hello: 'world', number: 42 });
+    expect(res.body).to.eql({ hello: 'world', number: 42 });
   });
 
   it('should receive text as strings with `includeUnparsed` option', async () => {
@@ -102,15 +94,15 @@ describe('includeUnparsed tests', async () => {
       .send('plain text content')
       .expect(200);
 
-    should.equal(requestSpy.calledOnce, true, 'Spy for /echo_body not called');
+    expect(requestSpy.calledOnce).to.equal(true, 'Spy for /echo_body not called');
     const req = requestSpy.firstCall.args[0].request;
-    should(req.body).equal('plain text content');
+    expect(req.body).to.equal('plain text content');
 
     // Raw text requests are still just text
-    should.equal(req.body[unparsed], undefined);
+    expect(req.body[unparsed]).to.be.an('undefined');
 
     // Text response is just text
-    should(res.body).have.properties({});
-    should(res.text).equal('plain text content');
+    expect(res.body).eql({});
+    expect(res.text).to.equal('plain text content');
   });
 });

--- a/test/unparsed.js
+++ b/test/unparsed.js
@@ -28,93 +28,89 @@ describe('includeUnparsed tests', async () => {
     const echoRouterLayer = router.stack.find(layer => layer.path === '/echo_body');
     const requestSpy = sinon.spy(echoRouterLayer.stack, '0');
 
-    return request(http.createServer(app.callback()))
+    const res = await request(http.createServer(app.callback()))
       .post('/echo_body')
       .type('application/json')
       .send(undefined)
-      .expect(200)
-      .then((res) => {
-        should.equal(requestSpy.calledOnce, true, 'Spy for /echo_body not called');
-        const req = requestSpy.firstCall.args[0].request;
+      .expect(200);
 
-        req.body.should.not.be.Undefined();
-        res.body.should.deepEqual({});
+    should.equal(requestSpy.calledOnce, true, 'Spy for /echo_body not called');
+    const req = requestSpy.firstCall.args[0].request;
 
-        req.body[unparsed].should.not.be.Undefined();
-        req.body[unparsed].should.be.a.String();
-        req.body[unparsed].should.have.length(0);
-      });
+    req.body.should.not.be.Undefined();
+    res.body.should.deepEqual({});
+
+    req.body[unparsed].should.not.be.Undefined();
+    req.body[unparsed].should.be.a.String();
+    req.body[unparsed].should.have.length(0);
   });
 
   it('should recieve `urlencoded` request bodies with the `includeUnparsed` option', async () => {
     const echoRouterLayer = router.stack.find(layer => layer.path === '/echo_body');
     const requestSpy = sinon.spy(echoRouterLayer.stack, '0');
 
-    return request(http.createServer(app.callback()))
+    const res = await request(http.createServer(app.callback()))
       .post('/echo_body')
       .type('application/x-www-form-urlencoded')
       .send({
         name: 'Test',
         followers: '97',
       })
-      .expect(200)
-      .then((res) => {
-        should.equal(requestSpy.calledOnce, true, 'Spy for /echo_body not called');
-        const req = requestSpy.firstCall.args[0].request;
-        req.body[unparsed].should.not.be.Undefined();
-        req.body[unparsed].should.be.a.String();
-        req.body[unparsed].should.equal('name=Test&followers=97');
+      .expect(200);
 
-        res.body.should.deepEqual({ name: 'Test', followers: '97' });
-      });
+    should.equal(requestSpy.calledOnce, true, 'Spy for /echo_body not called');
+    const req = requestSpy.firstCall.args[0].request;
+    req.body[unparsed].should.not.be.Undefined();
+    req.body[unparsed].should.be.a.String();
+    req.body[unparsed].should.equal('name=Test&followers=97');
+
+    res.body.should.deepEqual({ name: 'Test', followers: '97' });
   });
 
   it('should receive JSON request bodies as strings with the `includeUnparsed` option', async () => {
     const echoRouterLayer = router.stack.find(layer => layer.path === '/echo_body');
     const requestSpy = sinon.spy(echoRouterLayer.stack, '0');
 
-    return request(http.createServer(app.callback()))
+    const res = await request(http.createServer(app.callback()))
       .post('/echo_body')
       .type('application/json')
       .send({
         hello: 'world',
         number: 42,
       })
-      .expect(200)
-      .then((res) => {
-        should.equal(requestSpy.calledOnce, true, 'Spy for /echo_body not called');
-        const req = requestSpy.firstCall.args[0].request;
-        req.body[unparsed].should.not.be.Undefined();
-        req.body[unparsed].should.be.a.String();
-        req.body[unparsed].should.equal(JSON.stringify({
-          hello: 'world',
-          number: 42,
-        }));
+      .expect(200);
 
-        res.body.should.deepEqual({ hello: 'world', number: 42 });
-      });
+    should.equal(requestSpy.calledOnce, true, 'Spy for /echo_body not called');
+    const req = requestSpy.firstCall.args[0].request;
+    req.body[unparsed].should.not.be.Undefined();
+    req.body[unparsed].should.be.a.String();
+    req.body[unparsed].should.equal(JSON.stringify({
+      hello: 'world',
+      number: 42,
+    }));
+
+    res.body.should.deepEqual({ hello: 'world', number: 42 });
   });
 
   it('should receive text as strings with `includeUnparsed` option', async () => {
     const echoRouterLayer = router.stack.find(layer => layer.path === '/echo_body');
     const requestSpy = sinon.spy(echoRouterLayer.stack, '0');
 
-    return request(http.createServer(app.callback()))
+    const res = await request(http.createServer(app.callback()))
       .post('/echo_body')
       .type('text')
       .send('plain text content')
-      .expect(200)
-      .then((res) => {
-        should.equal(requestSpy.calledOnce, true, 'Spy for /echo_body not called');
-        const req = requestSpy.firstCall.args[0].request;
-        should(req.body).equal('plain text content');
+      .expect(200);
 
-        // Raw text requests are still just text
-        should.equal(req.body[unparsed], undefined);
+    should.equal(requestSpy.calledOnce, true, 'Spy for /echo_body not called');
+    const req = requestSpy.firstCall.args[0].request;
+    should(req.body).equal('plain text content');
 
-        // Text response is just text
-        should(res.body).have.properties({});
-        should(res.text).equal('plain text content');
-      });
+    // Raw text requests are still just text
+    should.equal(req.body[unparsed], undefined);
+
+    // Text response is just text
+    should(res.body).have.properties({});
+    should(res.text).equal('plain text content');
   });
 });


### PR DESCRIPTION
The existing tests are a mess right now and need to be cleaned up.

- [x] fix innefective assertions / swap `should.js` to `chai`
- [x] linting
- [x] code coverage
- [x] split tests up
- [x] update test dependencies

I introduced eslint with the airbnb style (it's reasonably similar) for linting and c8 for coverage. In order to keep this PR small and focused, we are not linting/changing the koa-body codebase.

I'm also dropping Node.js 6 from the CI test matrix because it is EOL as of April 2019, which is about when I think we can roll out the next major version of koa-body.