### PR TITLE
Remove ctx.request.fields reference from example

### DIFF
--- a/examples/multipart.js
+++ b/examples/multipart.js
@@ -30,7 +30,7 @@ router.get('/', (ctx) => {
 
 router.post('/', koaBody,
   (ctx) => {
-    console.log('fields: ', ctx.request.fields);
+    console.log('fields: ', ctx.request.body);
     // => {username: ""} - if empty
 
     console.log('files: ', ctx.request.files);


### PR DESCRIPTION
ctx.request.fields no longer exists, removing reference to it.

Should address #117.