### PR TITLE
Make body on Koa.BaseRequest non optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@ import { Files } from 'formidable';
 
 declare module "koa" {
     interface Request extends Koa.BaseRequest {
-        body?: any;
+        body: any;
         files?: Files;
     }
 }


### PR DESCRIPTION
I have a project where I am using a `koa` server and `apollo-server-koa` at the same time. `apollo-server-koa` is using `koa-bodyparser` and I am using `koa-body`. Therefore I get a mismatch on the type for body on module `koa` which breaks my build, as there are two different declarations of `body`

![image](https://user-images.githubusercontent.com/26043795/55007010-fc8ddb80-4fde-11e9-964e-ae24c7902d90.png)

There has already been a discussion on this topic, ref #119 where `koa-bodyparser` changed typings to this weird `{} | null | undefined` structure which was reverted back to `body: any;`, but I think being in sync with `koa-bodyparser` typings would be beneficial as it would allow for usage of both packages simultaneously. 

I don't know if changing the `body` type to being non optional would cause any breaking changes, but as far as I'm concerned I would have to migrate to `koa-bodyparser` if this is not resolved. 