### PR TITLE
Remove deprecated `strict` option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Breaking Changes
 - drops support for Node.js 6
+- deprecated `strict` option removed
 
 ### Non-Breaking Changes
 - TODO

--- a/README.md
+++ b/README.md
@@ -99,8 +99,7 @@ console.log('curl -i http://localhost:3000/users -d "name=test"');
 - `includeUnparsed` **{Boolean}** Toggles co-body returnRawBody option; if set to true, for form encodedand and JSON requests the raw, unparsed requesty body will be attached to `ctx.reqeust.body` using a `Symbol`, default `false`
 - `formidable` **{Object}** Options to pass to the formidable multipart parser
 - `onError` **{Function}** Custom error handle, if throw an error, you can customize the response - onError(error, context), default will throw
-- `strict` **{Boolean}** ***DEPRECATED*** If enabled, don't parse GET, HEAD, DELETE requests, default `true`
-- `parsedMethods` **{String[]}** Declares the HTTP methods where bodies will be parsed, default `['POST', 'PUT', 'PATCH']`. Replaces `strict` option.
+- `parsedMethods` **{String[]}** Declares the HTTP methods where bodies will be parsed, default `['POST', 'PUT', 'PATCH']`.
 
 ## A note about `parsedMethods`
 > see [http://tools.ietf.org/html/draft-ietf-httpbis-p2-semantics-19#section-6.3](http://tools.ietf.org/html/draft-ietf-httpbis-p2-semantics-19#section-6.3)

--- a/index.d.ts
+++ b/index.d.ts
@@ -140,17 +140,6 @@ declare namespace koaBody {
         onError?: (err: Error, ctx: Koa.Context) => void;
 
         /**
-         * {Boolean} If enabled, don't parse GET, HEAD, DELETE requests; deprecated.
-         *
-         * GET, HEAD, and DELETE requests have no defined semantics for the request body,
-         * but this doesn't mean they may not be valid in certain use cases.
-         * koa-body is strict by default
-         *
-         * see http://tools.ietf.org/html/draft-ietf-httpbis-p2-semantics-19#section-6.3
-         */
-        strict?: boolean;
-
-        /**
          * {String[]} What HTTP methods to enable body parsing for; should be used in preference to strict mode.
          *
          * GET, HEAD, and DELETE requests have no defined semantics for the request body,

--- a/index.js
+++ b/index.js
@@ -96,20 +96,6 @@ function requestbody(opts) {
   mergedOpts.includeUnparsed = 'includeUnparsed' in mergedOpts ? mergedOpts.includeUnparsed : false;
   mergedOpts.textLimit = 'textLimit' in mergedOpts ? mergedOpts.textLimit : '56kb';
 
-  // @todo: next major version, opts.strict support should be removed
-  if (mergedOpts.strict && mergedOpts.parsedMethods) {
-    throw new Error('Cannot use strict and parsedMethods options at the same time.');
-  }
-
-  if ('strict' in mergedOpts) {
-    console.warn('DEPRECATED: opts.strict has been deprecated in favor of opts.parsedMethods.');
-    if (mergedOpts.strict) {
-      mergedOpts.parsedMethods = ['POST', 'PUT', 'PATCH'];
-    } else {
-      mergedOpts.parsedMethods = ['POST', 'PUT', 'PATCH', 'GET', 'HEAD', 'DELETE'];
-    }
-  }
-
   mergedOpts.parsedMethods = 'parsedMethods' in mergedOpts ? mergedOpts.parsedMethods : ['POST', 'PUT', 'PATCH'];
   mergedOpts.parsedMethods = mergedOpts.parsedMethods.map(method => method.toUpperCase());
 

--- a/test/index.js
+++ b/test/index.js
@@ -245,39 +245,6 @@ describe('koa-body', async () => {
     expect(res.text).to.equal('plain text');
   });
 
-  describe('strict mode', async () => {
-    beforeEach(async () => {
-      // push an additional, to test the multi query
-      database.users.push({ name: 'charlike' });
-    });
-
-    it('can enable strict mode', async () => {
-      app.use(koaBody({ strict: true }));
-      app.use(router.routes());
-
-      await request(http.createServer(app.callback()))
-        .delete('/users/charlike')
-        .type('application/x-www-form-urlencoded')
-        .send({ multi: true })
-        .expect(204);
-
-      expect(database.users.find(element => element.name === 'charlike')).to.not.be.a('undefined');
-    });
-
-    it('can disable strict mode', async () => {
-      app.use(koaBody({ strict: false }));
-      app.use(router.routes());
-
-      await request(http.createServer(app.callback()))
-        .delete('/users/charlike')
-        .type('application/x-www-form-urlencoded')
-        .send({ multi: true })
-        .expect(204);
-
-      expect(database.users.find(element => element.name === 'charlike')).to.be.a('undefined');
-    });
-  });
-
   describe('parsedMethods options', async () => {
     beforeEach(async () => {
       // push an additional, to test the multi query
@@ -309,20 +276,6 @@ describe('koa-body', async () => {
 
       expect(database.users.find(element => element.name === 'charlike')).to.not.be.a('undefined');
     });
-
-    it('cannot use strict mode and parsedMethods options at the same time', async () => {
-      let err;
-      try {
-        app.use(koaBody({
-          parsedMethods: ['POST', 'PUT', 'PATCH'],
-          strict: true,
-        }));
-      } catch (_err) {
-        err = _err;
-      }
-
-      expect(err.message).to.equal('Cannot use strict and parsedMethods options at the same time.');
-    });
   });
 
   /**
@@ -330,7 +283,7 @@ describe('koa-body', async () => {
    */
   describe('POST json request body', async () => {
     it('should set the follower count', async () => {
-      app.use(koaBody({ strict: false }));
+      app.use(koaBody());
       app.use(router.routes());
 
       const res = await request(http.createServer(app.callback()))
@@ -349,7 +302,7 @@ describe('koa-body', async () => {
     let response;
 
     beforeEach(async () => {
-      app.use(koaBody({ strict: false }));
+      app.use(koaBody({ parsedMethods: ['POST', 'PUT', 'PATCH', 'GET'] }));
       app.use(router.routes());
       database.users.push({
         name: 'foo',


### PR DESCRIPTION
The `strict` option was deprecated after being superseded by the more
granular `parsedMethods` option in 4.1.0.

Fixes #137, and affects #139.