### PR TITLE
Removing patchNode, patchKoa options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ### Breaking Changes
 - drops support for Node.js 6
 - deprecated `strict` option removed
+- drops `patchNode` option
+  - there is not longer an option to add body to the node `request` object
+- drops `patchKoa` option
+  - body is always added to Koa's `ctx.request` object
 
 ### Non-Breaking Changes
 - TODO

--- a/README.md
+++ b/README.md
@@ -85,8 +85,6 @@ console.log('curl -i http://localhost:3000/users -d "name=test"');
 ## Options
 > Options available for `koa-body`. Four custom options, and others are from `raw-body` and `formidable`.
 
-- `patchNode` **{Boolean}** Patch request body to Node's `ctx.req`, default `false`
-- `patchKoa` **{Boolean}** Patch request body to Koa's `ctx.request`, default `true`
 - `jsonLimit` **{String|Integer}** The byte (if integer) limit of the JSON body, default `1mb`
 - `formLimit` **{String|Integer}** The byte (if integer) limit of the form body, default `56kb`
 - `textLimit` **{String|Integer}** The byte (if integer) limit of the text body, default `56kb`

--- a/index.d.ts
+++ b/index.d.ts
@@ -55,20 +55,6 @@ declare namespace koaBody {
     }
     interface IKoaBodyOptions {
         /**
-         * {Boolean} Patch request body to Node's ctx.req, default false
-         *
-         * Note: You can patch request body to Node or Koa in same time if you want.
-         */
-        patchNode?: boolean;
-
-        /**
-         * {Boolean} Patch request body to Koa's ctx.request, default true
-         *
-         * Note: You can patch request body to Node or Koa in same time if you want.
-         */
-        patchKoa?: boolean;
-
-        /**
          * {String|Integer} The byte (if integer) limit of the JSON body, default 1mb
          */
         jsonLimit?: string|number;

--- a/index.js
+++ b/index.js
@@ -81,8 +81,6 @@ function formy(ctx, opts) {
 function requestbody(opts) {
   const mergedOpts = opts || {};
   mergedOpts.onError = 'onError' in mergedOpts ? mergedOpts.onError : false;
-  mergedOpts.patchNode = 'patchNode' in mergedOpts ? mergedOpts.patchNode : false;
-  mergedOpts.patchKoa = 'patchKoa' in mergedOpts ? mergedOpts.patchKoa : true;
   mergedOpts.multipart = 'multipart' in mergedOpts ? mergedOpts.multipart : false;
   mergedOpts.urlencoded = 'urlencoded' in mergedOpts ? mergedOpts.urlencoded : true;
   mergedOpts.json = 'json' in mergedOpts ? mergedOpts.json : true;
@@ -146,31 +144,16 @@ function requestbody(opts) {
       return next();
     })
       .then((body) => {
-        if (mergedOpts.patchNode) {
-          if (isMultiPart(ctx, mergedOpts)) {
-            ctx.req.body = body.fields;
-            ctx.req.files = body.files;
-          } else if (mergedOpts.includeUnparsed) {
-            ctx.req.body = body.parsed || {};
-            if (!ctx.is('text')) {
-              ctx.req.body[symbolUnparsed] = body.raw;
-            }
-          } else {
-            ctx.req.body = body;
+        if (isMultiPart(ctx, mergedOpts)) {
+          ctx.request.body = body.fields;
+          ctx.request.files = body.files;
+        } else if (mergedOpts.includeUnparsed) {
+          ctx.request.body = body.parsed || {};
+          if (!ctx.is('text')) {
+            ctx.request.body[symbolUnparsed] = body.raw;
           }
-        }
-        if (mergedOpts.patchKoa) {
-          if (isMultiPart(ctx, mergedOpts)) {
-            ctx.request.body = body.fields;
-            ctx.request.files = body.files;
-          } else if (mergedOpts.includeUnparsed) {
-            ctx.request.body = body.parsed || {};
-            if (!ctx.is('text')) {
-              ctx.request.body[symbolUnparsed] = body.raw;
-            }
-          } else {
-            ctx.request.body = body;
-          }
+        } else {
+          ctx.request.body = body;
         }
         return next();
       });


### PR DESCRIPTION
Removing the patchNode and patchKoa options.

As part of the next major release, addresses https://github.com/dlau/koa-body/issues/139#issuecomment-480223780

Ping @damianb to review.