### PR TITLE
Add test for onError not capturing downstream errors

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -278,6 +278,34 @@ describe('koa-body', async () => {
     });
   });
 
+  describe('onError option', () => {
+    it('onError should not capture errors thrown in downstream middleware', async () => {
+      let koaBodyError
+      app.use(async (ctx, next) => {
+        try {
+          await next();
+        } catch (err) {
+          ctx.status = 201;
+        }
+      });
+      app.use(koaBody({
+        onError: (err, ctx) => {
+          koaBodyError = err
+        }
+      }));
+      app.use(async (ctx, next) => {
+        ctx.status = 200;
+        throw new Error();
+      });
+
+      await request(http.createServer(app.callback()))
+        .get('/test')
+        .expect(201);
+
+      expect(koaBodyError).to.be.undefined;
+    });
+  });
+
   /**
    * JSON request body
    */

--- a/test/index.js
+++ b/test/index.js
@@ -280,7 +280,7 @@ describe('koa-body', async () => {
 
   describe('onError option', () => {
     it('onError should not capture errors thrown in downstream middleware', async () => {
-      let koaBodyError
+      let koaBodyError;
       app.use(async (ctx, next) => {
         try {
           await next();
@@ -290,7 +290,7 @@ describe('koa-body', async () => {
       });
       app.use(koaBody({
         onError: (err, ctx) => {
-          koaBodyError = err
+          koaBodyError = err;
         }
       }));
       app.use(async (ctx, next) => {


### PR DESCRIPTION
A bit hacky, unfortunately, because I'm wary of trying to modify state from an "onevent"-esque function.  Should cover that #59's fix is not broken by future changes.