### PR TITLE
Reflow middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,12 @@
 - drops support for Node.js 6
 - deprecated `strict` option removed
 - drops `patchNode` option
-  - there is no longer an option to add body to the node `request` object
+  - there is not longer an option to add body to the node `request` object
 - drops `patchKoa` option
   - body is always added to Koa's `ctx.request` object
 - `ctx.request.body` is not modified if another body parser has run
 - `ctx.request.body`, if `koa-body` executes, is always defined
-- drops support for the `onError` option; if you want to handle presentation of parsing errors, you must use a middleware loaded before `koa-body`.
+- `onError` option now throws an error if provided something other than a function
 
 ### Non-Breaking Changes
 - internally refactored to use async/await

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,12 @@
 - drops support for Node.js 6
 - deprecated `strict` option removed
 - drops `patchNode` option
-  - there is not longer an option to add body to the node `request` object
+  - there is no longer an option to add body to the node `request` object
 - drops `patchKoa` option
   - body is always added to Koa's `ctx.request` object
 - `ctx.request.body` is not modified if another body parser has run
 - `ctx.request.body`, if `koa-body` executes, is always defined
-- `onError` option now throws an error if provided something other than a function
+- drops support for the `onError` option; if you want to handle presentation of parsing errors, you must use a middleware loaded before `koa-body`.
 
 ### Non-Breaking Changes
 - internally refactored to use async/await

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@
   - there is not longer an option to add body to the node `request` object
 - drops `patchKoa` option
   - body is always added to Koa's `ctx.request` object
+- `ctx.request.body` is not modified if another body parser has run
+- `ctx.request.body`, if `koa-body` executes, is always defined
+- `onError` option now throws an error if provided something other than a function
 
 ### Non-Breaking Changes
-- TODO
+- internally refactored to use async/await
 
 ## 4.1.0
 - adds `parsedMethods` option to specify which request methods will be parsed

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ console.log('curl -i http://localhost:3000/users -d "name=test"');
 - `jsonStrict` **{Boolean}** Toggles co-body strict mode; if set to true - only parses arrays or objects, default `true`
 - `includeUnparsed` **{Boolean}** Toggles co-body returnRawBody option; if set to true, for form encodedand and JSON requests the raw, unparsed requesty body will be attached to `ctx.reqeust.body` using a `Symbol`, default `false`
 - `formidable` **{Object}** Options to pass to the formidable multipart parser
-- `onError` **{Function}** Custom error handle, if throw an error, you can customize the response - onError(error, context), default will throw
+- `onError` **{Function}** Custom error handler. If a function is provided, a custom error can be thrown. By default, koa-body will throw any parse errors.
 - `parsedMethods` **{String[]}** Declares the HTTP methods where bodies will be parsed, default `['POST', 'PUT', 'PATCH']`.
 
 ## A note about `parsedMethods`

--- a/README.md
+++ b/README.md
@@ -95,8 +95,7 @@ console.log('curl -i http://localhost:3000/users -d "name=test"');
 - `json` **{Boolean}** Parse json bodies, default `true`
 - `jsonStrict` **{Boolean}** Toggles co-body strict mode; if set to true - only parses arrays or objects, default `true`
 - `includeUnparsed` **{Boolean}** Toggles co-body returnRawBody option; if set to true, for form encodedand and JSON requests the raw, unparsed requesty body will be attached to `ctx.reqeust.body` using a `Symbol`, default `false`
-- `formidable` **{Object}** Options to pass to the formidable multipart parser
-- `onError` **{Function}** Custom error handler. If a function is provided, a custom error can be thrown. By default, koa-body will throw any parse errors.
+- `formidable` **{Object}** Options to pass to the formidable multipart parserarse errors.
 - `parsedMethods` **{String[]}** Declares the HTTP methods where bodies will be parsed, default `['POST', 'PUT', 'PATCH']`.
 
 ## A note about `parsedMethods`

--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ console.log('curl -i http://localhost:3000/users -d "name=test"');
 - `jsonStrict` **{Boolean}** Toggles co-body strict mode; if set to true - only parses arrays or objects, default `true`
 - `includeUnparsed` **{Boolean}** Toggles co-body returnRawBody option; if set to true, for form encodedand and JSON requests the raw, unparsed requesty body will be attached to `ctx.reqeust.body` using a `Symbol`, default `false`
 - `formidable` **{Object}** Options to pass to the formidable multipart parser
+<<<<<<< HEAD
+=======
+- `onError` **{Function}** Custom error handler. If a function is provided, a custom error can be thrown. By default, koa-body will throw any parse errors.
+>>>>>>> parent of 1b91816... Remove support for "onError" option.
 - `parsedMethods` **{String[]}** Declares the HTTP methods where bodies will be parsed, default `['POST', 'PUT', 'PATCH']`.
 
 ## A note about `parsedMethods`

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ console.log('curl -i http://localhost:3000/users -d "name=test"');
 - `json` **{Boolean}** Parse json bodies, default `true`
 - `jsonStrict` **{Boolean}** Toggles co-body strict mode; if set to true - only parses arrays or objects, default `true`
 - `includeUnparsed` **{Boolean}** Toggles co-body returnRawBody option; if set to true, for form encodedand and JSON requests the raw, unparsed requesty body will be attached to `ctx.reqeust.body` using a `Symbol`, default `false`
-- `formidable` **{Object}** Options to pass to the formidable multipart parserarse errors.
+- `formidable` **{Object}** Options to pass to the formidable multipart parser
 - `parsedMethods` **{String[]}** Declares the HTTP methods where bodies will be parsed, default `['POST', 'PUT', 'PATCH']`.
 
 ## A note about `parsedMethods`

--- a/index.d.ts
+++ b/index.d.ts
@@ -121,6 +121,11 @@ declare namespace koaBody {
         formidable?: IKoaBodyFormidableOptions;
 
         /**
+         * {Function} Custom error handler. If a function is provided, a custom error can be thrown. By default, koa-body will throw any parse errors.
+         */
+        onError?: (err: Error, ctx: Koa.Context) => void;
+
+        /**
          * {String[]} What HTTP methods to enable body parsing for; should be used in preference to strict mode.
          *
          * GET, HEAD, and DELETE requests have no defined semantics for the request body,

--- a/index.d.ts
+++ b/index.d.ts
@@ -121,7 +121,7 @@ declare namespace koaBody {
         formidable?: IKoaBodyFormidableOptions;
 
         /**
-         * {Function} Custom error handle, if throw an error, you can customize the response - onError(error, context), default will throw
+         * {Function} Custom error handler. If a function is provided, a custom error can be thrown. By default, koa-body will throw any parse errors.
          */
         onError?: (err: Error, ctx: Koa.Context) => void;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -121,11 +121,6 @@ declare namespace koaBody {
         formidable?: IKoaBodyFormidableOptions;
 
         /**
-         * {Function} Custom error handler. If a function is provided, a custom error can be thrown. By default, koa-body will throw any parse errors.
-         */
-        onError?: (err: Error, ctx: Koa.Context) => void;
-
-        /**
          * {String[]} What HTTP methods to enable body parsing for; should be used in preference to strict mode.
          *
          * GET, HEAD, and DELETE requests have no defined semantics for the request body,

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@ import { Files } from 'formidable';
 
 declare module "koa" {
     interface Request extends Koa.BaseRequest {
-        body?: any;
+        body: any;
         files?: Files;
     }
 }

--- a/index.js
+++ b/index.js
@@ -140,7 +140,6 @@ function requestbody(_opts) {
 
       if (opts.includeUnparsed) {
         ctx.request.body = body.parsed || {};
-        ctx.request.body[symbolUnparsed] = body.raw;
       } else {
         ctx.request.body = body;
       }

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ const symbolUnparsed = require('./unparsed.js');
  * @api private
  */
 function formy(ctx, opts) {
-  return new Promise(((resolve, reject) => {
+  return new Promise((resolve, reject) => {
     const fields = {};
     const files = {};
     const form = new forms.IncomingForm(opts);
@@ -43,7 +43,8 @@ function formy(ctx, opts) {
         } else {
           fields[field] = value;
         }
-      }).on('file', (field, file) => {
+      })
+      .on('file', (field, file) => {
         if (files[field]) {
           if (!Array.isArray(files[field])) {
             files[field] = [files[field]];
@@ -60,7 +61,7 @@ function formy(ctx, opts) {
     }
 
     form.parse(ctx.req);
-  }));
+  });
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -73,7 +73,6 @@ function formy(ctx, opts) {
 function requestbody(_opts) {
   const opts = _opts || {};
 
-  opts.onError = 'onError' in opts ? opts.onError : ((err) => { throw err; });
   opts.multipart = 'multipart' in opts ? opts.multipart : false;
   opts.urlencoded = 'urlencoded' in opts ? opts.urlencoded : true;
   opts.json = 'json' in opts ? opts.json : true;
@@ -90,10 +89,6 @@ function requestbody(_opts) {
   opts.parsedMethods = 'parsedMethods' in opts ? opts.parsedMethods : ['POST', 'PUT', 'PATCH'];
   opts.parsedMethods = opts.parsedMethods.map(method => method.toUpperCase());
 
-  if (typeof opts.onError !== 'function') {
-    throw new Error('opts.onError must be a function');
-  }
-
   return async function closure(ctx, next) {
     // bail out if the request body has already been handled by another body parser
     if (ctx.request.body !== undefined) {
@@ -108,56 +103,52 @@ function requestbody(_opts) {
       return next();
     }
 
-    try {
-      if (opts.json && ctx.is('json')) {
-        const body = await buddy.json(ctx, {
-          encoding: opts.encoding,
-          limit: opts.jsonLimit,
-          strict: opts.jsonStrict,
-          returnRawBody: opts.includeUnparsed,
-        });
+    if (opts.json && ctx.is('json')) {
+      const body = await buddy.json(ctx, {
+        encoding: opts.encoding,
+        limit: opts.jsonLimit,
+        strict: opts.jsonStrict,
+        returnRawBody: opts.includeUnparsed,
+      });
 
-        if (opts.includeUnparsed) {
-          ctx.request.body = body.parsed || {};
-          ctx.request.body[symbolUnparsed] = body.raw;
-        } else {
-          ctx.request.body = body;
-        }
-      } else if (opts.urlencoded && ctx.is('urlencoded')) {
-        const body = await buddy.form(ctx, {
-          encoding: opts.encoding,
-          limit: opts.formLimit,
-          queryString: opts.queryString,
-          returnRawBody: opts.includeUnparsed,
-        });
-
-        if (opts.includeUnparsed) {
-          ctx.request.body = body.parsed || {};
-          ctx.request.body[symbolUnparsed] = body.raw;
-        } else {
-          ctx.request.body = body;
-        }
-      } else if (opts.text && ctx.is('text')) {
-        const body = await buddy.text(ctx, {
-          encoding: opts.encoding,
-          limit: opts.textLimit,
-          returnRawBody: opts.includeUnparsed,
-        });
-
-        if (opts.includeUnparsed) {
-          ctx.request.body = body.parsed || {};
-          ctx.request.body[symbolUnparsed] = body.raw;
-        } else {
-          ctx.request.body = body;
-        }
-      } else if (opts.multipart && ctx.is('multipart')) {
-        const body = await formy(ctx, opts.formidable);
-
-        ctx.request.body = body.fields;
-        ctx.request.files = body.files;
+      if (opts.includeUnparsed) {
+        ctx.request.body = body.parsed || {};
+        ctx.request.body[symbolUnparsed] = body.raw;
+      } else {
+        ctx.request.body = body;
       }
-    } catch (err) {
-      opts.onError(err, ctx);
+    } else if (opts.urlencoded && ctx.is('urlencoded')) {
+      const body = await buddy.form(ctx, {
+        encoding: opts.encoding,
+        limit: opts.formLimit,
+        queryString: opts.queryString,
+        returnRawBody: opts.includeUnparsed,
+      });
+
+      if (opts.includeUnparsed) {
+        ctx.request.body = body.parsed || {};
+        ctx.request.body[symbolUnparsed] = body.raw;
+      } else {
+        ctx.request.body = body;
+      }
+    } else if (opts.text && ctx.is('text')) {
+      const body = await buddy.text(ctx, {
+        encoding: opts.encoding,
+        limit: opts.textLimit,
+        returnRawBody: opts.includeUnparsed,
+      });
+
+      if (opts.includeUnparsed) {
+        ctx.request.body = body.parsed || {};
+        ctx.request.body[symbolUnparsed] = body.raw;
+      } else {
+        ctx.request.body = body;
+      }
+    } else if (opts.multipart && ctx.is('multipart')) {
+      const body = await formy(ctx, opts.formidable);
+
+      ctx.request.body = body.fields;
+      ctx.request.files = body.files;
     }
 
     return next();

--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ function requestbody(_opts) {
   opts.parsedMethods = opts.parsedMethods.map(method => method.toUpperCase());
 
   if (typeof opts.onError !== 'function') {
-    throw new Error('opts.onError must be provided a function');
+    throw new Error('opts.onError must be a function');
   }
 
   return async function closure(ctx, next) {

--- a/test/index.js
+++ b/test/index.js
@@ -278,48 +278,6 @@ describe('koa-body', async () => {
     });
   });
 
-  describe('onError option', () => {
-    it('onError should not capture errors thrown in downstream middleware', async () => {
-      let koaBodyError;
-      app.use(async (ctx, next) => {
-        try {
-          await next();
-        } catch (err) {
-          ctx.status = 201;
-        }
-      });
-      app.use(koaBody({
-        onError: (err) => {
-          koaBodyError = err;
-        },
-      }));
-      app.use(async (ctx) => {
-        ctx.status = 200;
-        throw new Error();
-      });
-
-      await request(http.createServer(app.callback()))
-        .get('/test')
-        .expect(201);
-
-      expect(koaBodyError).to.be.an('undefined');
-    });
-
-    it('onError should throw when provided something other than a function', () => {
-      let err;
-      try {
-        app.use(koaBody({
-          onError: 10,
-        }));
-      } catch (_err) {
-        err = _err;
-      }
-
-      expect(err).to.be.an('Error');
-      expect(err.message).to.equal('opts.onError must be a function');
-    });
-  });
-
   /**
    * JSON request body
    */

--- a/test/index.js
+++ b/test/index.js
@@ -278,6 +278,34 @@ describe('koa-body', async () => {
     });
   });
 
+  describe('onError option', () => {
+    it('onError should not capture errors thrown in downstream middleware', async () => {
+      let koaBodyError
+      app.use(async (ctx, next) => {
+        try {
+          await next();
+        } catch (err) {
+          ctx.status = 201;
+        }
+      });
+      app.use(koaBody({
+        onError: (err, ctx) => {
+          koaBodyError = err
+        }
+      }));
+      app.use(async (ctx, next) => {
+        ctx.status = 200;
+        throw new Error();
+      });
+
+      await request(http.createServer(app.callback()))
+        .get('/test')
+        .expect(201);
+
+      expect(koaBodyError).to.be.undefined;
+    });
+  });
+
   /**
    * JSON request body
    */

--- a/test/index.js
+++ b/test/index.js
@@ -278,6 +278,48 @@ describe('koa-body', async () => {
     });
   });
 
+  describe('onError option', () => {
+    it('onError should not capture errors thrown in downstream middleware', async () => {
+      let koaBodyError;
+      app.use(async (ctx, next) => {
+        try {
+          await next();
+        } catch (err) {
+          ctx.status = 201;
+        }
+      });
+      app.use(koaBody({
+        onError: (err) => {
+          koaBodyError = err;
+        },
+      }));
+      app.use(async (ctx) => {
+        ctx.status = 200;
+        throw new Error();
+      });
+
+      await request(http.createServer(app.callback()))
+        .get('/test')
+        .expect(201);
+
+      expect(koaBodyError).to.be.an('undefined');
+    });
+
+    it('onError should throw when provided something other than a function', () => {
+      let err;
+      try {
+        app.use(koaBody({
+          onError: 10,
+        }));
+      } catch (_err) {
+        err = _err;
+      }
+
+      expect(err).to.be.an('Error');
+      expect(err.message).to.equal('opts.onError must be a function');
+    });
+  });
+
   /**
    * JSON request body
    */

--- a/test/index.js
+++ b/test/index.js
@@ -289,11 +289,11 @@ describe('koa-body', async () => {
         }
       });
       app.use(koaBody({
-        onError: (err, ctx) => {
+        onError: (err) => {
           koaBodyError = err;
-        }
+        },
       }));
-      app.use(async (ctx, next) => {
+      app.use(async (ctx) => {
         ctx.status = 200;
         throw new Error();
       });
@@ -302,14 +302,14 @@ describe('koa-body', async () => {
         .get('/test')
         .expect(201);
 
-      expect(koaBodyError).to.be.undefined;
+      expect(koaBodyError).to.be.an('undefined');
     });
 
     it('onError should throw when provided something other than a function', () => {
       let err;
       try {
         app.use(koaBody({
-          onError: 10
+          onError: 10,
         }));
       } catch (_err) {
         err = _err;

--- a/test/index.js
+++ b/test/index.js
@@ -280,7 +280,7 @@ describe('koa-body', async () => {
 
   describe('onError option', () => {
     it('onError should not capture errors thrown in downstream middleware', async () => {
-      let koaBodyError
+      let koaBodyError;
       app.use(async (ctx, next) => {
         try {
           await next();
@@ -290,7 +290,7 @@ describe('koa-body', async () => {
       });
       app.use(koaBody({
         onError: (err, ctx) => {
-          koaBodyError = err
+          koaBodyError = err;
         }
       }));
       app.use(async (ctx, next) => {

--- a/test/index.js
+++ b/test/index.js
@@ -316,7 +316,7 @@ describe('koa-body', async () => {
       }
 
       expect(err).to.be.an('Error');
-      expect(err.message).to.equal('opts.onError must be provided a function');
+      expect(err.message).to.equal('opts.onError must be a function');
     });
   });
 

--- a/test/index.js
+++ b/test/index.js
@@ -304,6 +304,20 @@ describe('koa-body', async () => {
 
       expect(koaBodyError).to.be.undefined;
     });
+
+    it('onError should throw when provided something other than a function', () => {
+      let err;
+      try {
+        app.use(koaBody({
+          onError: 10
+        }));
+      } catch (_err) {
+        err = _err;
+      }
+
+      expect(err).to.be.an('Error');
+      expect(err.message).to.equal('opts.onError must be provided a function');
+    });
   });
 
   /**


### PR DESCRIPTION
Implicitly depends on #149 being merged.  Should address #148, and contribute to #139 overall.

- Multiple changes throughout internally, though it's mostly a refactor in and of itself.  A test was added for the BC-breaking behavior of verifying that `opts.onError` is a function (which helps simplify things by being able to make that assumption downstream).

- `opts` arg for the closure function was renamed to `_opts` because it's only referenced once, and `mergedOpts` renamed to `opts` because we use it everywhere internally.  This helps readability a bit and keeps us consistent with the readme documentation.

- async/await was introduced to help clean up some of our error handling, and then internally we're moving away from the default `onError` value of `false` in order to ensure that there is *always* something callable available.  We may want to document that it's a good idea in onError to rethrow, or possibly just turn the callable itself into a no-op function and then rethrow regardless; I'm not sure which makes more sense at the moment, but ideally whichever path we take, we should try to address #112.

- `isMultipart` was made redundant and eliminated.

- if something else has defined `ctx.request.body` koa-body will disable itself; this is consistent with the typings, too.

- `koa-body` now always sets `ctx.request.body` which solves that bit of heartache for many.  This implictly makes #144 obsolete.

- `onError` option removed - see https://github.com/dlau/koa-body/pull/150#issuecomment-488371302

We're now also handling each branching point (or rather, *type* of body) explicitly, which should allow us to try and tackle something like #72 easier.

Ping @MarkHerhold for review.