### PR TITLE
Support application/csp-report parsed as json

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ console.log('curl -i http://localhost:3000/users -d "name=test"');
 - `onError` **{Function}** Custom error handle, if throw an error, you can customize the response - onError(error, context), default will throw
 - `strict` **{Boolean}** ***DEPRECATED*** If enabled, don't parse GET, HEAD, DELETE requests, default `true`
 - `parsedMethods` **{String[]}** Declares the HTTP methods where bodies will be parsed, default `['POST', 'PUT', 'PATCH']`. Replaces `strict` option.
+- `cspReportJson` **{Boolean}** Parses `application/csp-report` like json, default `false`
 
 ## A note about `parsedMethods`
 > see [http://tools.ietf.org/html/draft-ietf-httpbis-p2-semantics-19#section-6.3](http://tools.ietf.org/html/draft-ietf-httpbis-p2-semantics-19#section-6.3)

--- a/index.js
+++ b/index.js
@@ -47,6 +47,7 @@ function requestbody(opts) {
   opts.formidable = 'formidable' in opts ? opts.formidable : {};
   opts.includeUnparsed = 'includeUnparsed' in opts ? opts.includeUnparsed : false
   opts.textLimit = 'textLimit' in opts ? opts.textLimit : '56kb';
+  opts.cspReportJson = 'cspReportJson' in opts ? opts.cspReportJson : false;
 
   // @todo: next major version, opts.strict support should be removed
   if (opts.strict && opts.parsedMethods) {
@@ -70,7 +71,15 @@ function requestbody(opts) {
     // only parse the body on specifically chosen methods
     if (opts.parsedMethods.includes(ctx.method.toUpperCase())) {
       try {
-        if (opts.json && ctx.is('json')) {
+        var isJson = opts.json &&
+        (
+          ctx.is('json') ||
+          (
+            opts.cspReportJson &&
+            ctx.is('application/csp-report')
+          )
+        );
+        if (isJson) {
           bodyPromise = buddy.json(ctx, {
             encoding: opts.encoding,
             limit: opts.jsonLimit,


### PR DESCRIPTION
This PR adds an optional `cspReportJson` flag that enables request bodies of type `application/csp-report` to be parsed as JSON.

Content Security Policy settings allow optional reporting of violations to a url. These reports have the `Content-Type` of [`application/csp-report`](https://www.w3.org/TR/CSP2/#violation-reports). Their payloads however are [actually JSON](https://www.w3.org/TR/CSP2/#example-violation-report).

I've put this feature behind a flag to not disrupt existing behavior. I've added to the options section of the README. I attempted to add some tests, but `supertest` doesn't support `application/csp-report` request types. This solves https://github.com/dlau/koa-body/issues/73.

Let me know if you have any questions/comments/concerns. Thanks for your work on this fantastic library.