### PR TITLE
Add support for JSON Patch, JSON API and CSP report

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ npm install koa-body
   * **multipart/form-data**
   * **application/x-www-urlencoded**
   * **application/json**
+  * **application/json-patch+json**
+  * **application/vnd.api+json**
+  * **application/csp-report**
 - option for patch to Koa or Node, or either
 - file uploads
 - body, fields and files size limiting

--- a/index.js
+++ b/index.js
@@ -24,6 +24,13 @@ const symbolUnparsed = require('./unparsed.js');
 
 module.exports = requestbody;
 
+const jsonTypes = [
+  'application/json',
+  'application/json-patch+json',
+  'application/vnd.api+json',
+  'application/csp-report'
+];
+
 /**
  *
  * @param {Object} options
@@ -70,7 +77,7 @@ function requestbody(opts) {
     // only parse the body on specifically chosen methods
     if (opts.parsedMethods.includes(ctx.method.toUpperCase())) {
       try {
-        if (opts.json && ctx.is('json')) {
+        if (opts.json && ctx.is(jsonTypes)) {
           bodyPromise = buddy.json(ctx, {
             encoding: opts.encoding,
             limit: opts.jsonLimit,

--- a/test/index.js
+++ b/test/index.js
@@ -618,9 +618,9 @@ describe('koa-body', () => {
             a: 'foo',
             b: [42]
           }], done);
-      })
+      });
     }
-  })
+  });
 
   const ERR_413_STATUSTEXT = 'request entity too large';
 

--- a/test/index.js
+++ b/test/index.js
@@ -580,8 +580,8 @@ describe('koa-body', () => {
 
       // NOTE: application/csp-report is not supported by superagent
       // See https://github.com/visionmedia/superagent/issues/1482
-      //'application/csp-report'
-    ]
+      // 'application/csp-report'
+    ];
 
     for (const type of types) {
       it(`should decode body as JSON object for type ${type}`, (done) => {
@@ -599,7 +599,7 @@ describe('koa-body', () => {
             a: 'foo',
             b: [42]
           }, done);
-      })
+      });
     }
 
     for (const type of types) {


### PR DESCRIPTION
Similar to koajs/bodyparser/pull/8, adds support for JSON Patch, JSON API and CSP report:

- `application/json-patch+json` (https://tools.ietf.org/html/rfc6902)
- `application/vnd.api+json` (https://jsonapi.org/)
- `application/csp-report` (https://www.w3.org/TR/CSP2/#violation-reports)

Extends #160 (though this PR doesn't introduce new option)

Tests added:
```
JSON media types
      √ should decode body as JSON object for type application/json
      √ should decode body as JSON object for type application/json-patch+json
      √ should decode body as JSON object for type application/vnd.api+json
      √ should decode body as JSON array for type application/json
      √ should decode body as JSON array for type application/json-patch+json
      √ should decode body as JSON array for type application/vnd.api+json
```