### PR TITLE
koa module definition bug fix

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 import * as Koa from "koa";
 import { Files } from 'formidable';
 
-declare module "koa" {
+declare module koa {
     interface Request extends Koa.BaseRequest {
         body?: any;
         files?: Files;


### PR DESCRIPTION
When I build a typescript project and compile it, console will report the following error:
``` text
Invalid module name in augmentation. Module 'koa' resolves to an untyped module at 'koa/lib/application.js', which cannot be augmented.
```