### PR TITLE
fix(typescript): declaration file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,8 @@
 import * as Koa from "koa";
 import { Files } from 'formidable';
 
-declare module koa {
-    interface Request extends Koa.BaseRequest {
+declare module "koa" {
+    interface Request {
         body?: any;
         files?: Files;
     }
@@ -163,6 +163,6 @@ declare namespace koaBody {
     }
 }
 
-declare function koaBody (options?: koaBody.IKoaBodyOptions): Koa.Middleware<{}, {}>;
+declare function koaBody (options?: koaBody.IKoaBodyOptions): Koa.Middleware;
 
 export = koaBody;


### PR DESCRIPTION
When installing the package, the ambient declaration didn't seem to be applied.
I updated the file by using the same approach as the `koa-bodyparser` package does (https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/koa-bodyparser/index.d.ts).
After this change, I was able to access the `body` and `files` properties.