### PR TITLE
support all text content types

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,14 @@ npm install koa-body
 ```
 
 ## Features
-- can handle three type requests
+- can handle requests such as:
   * **multipart/form-data**
   * **application/x-www-urlencoded**
   * **application/json**
   * **application/json-patch+json**
   * **application/vnd.api+json**
   * **application/csp-report**
+  * **text/xml**
 - option for patch to Koa or Node, or either
 - file uploads
 - body, fields and files size limiting
@@ -96,8 +97,8 @@ console.log('curl -i http://localhost:3000/users -d "name=test"');
 - `encoding` **{String}** Sets encoding for incoming form fields, default `utf-8`
 - `multipart` **{Boolean}** Parse multipart bodies, default `false`
 - `urlencoded` **{Boolean}** Parse urlencoded bodies, default `true`
-- `text` **{Boolean}** Parse text bodies, default `true`
-- `json` **{Boolean}** Parse json bodies, default `true`
+- `text` **{Boolean}** Parse text bodies, such as XML, default `true`
+- `json` **{Boolean}** Parse JSON bodies, default `true`
 - `jsonStrict` **{Boolean}** Toggles co-body strict mode; if set to true - only parses arrays or objects, default `true`
 - `includeUnparsed` **{Boolean}** Toggles co-body returnRawBody option; if set to true, for form encodedand and JSON requests the raw, unparsed requesty body will be attached to `ctx.request.body` using a `Symbol`, default `false`
 - `formidable` **{Object}** Options to pass to the formidable multipart parser

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Request Body: {"name":"test"}%
 **For a more comprehensive example, see** `examples/multipart.js`
 
 ## Usage with [koa-router](https://github.com/alexmingoia/koa-router)
-> It's generally better to only parse the body as needed, if using a router that supports middleware composition, we can inject it only for certain routes.
+It's generally better to only parse the body as needed, if using a router that supports middleware composition, we can inject it only for certain routes.
 
 ```js
 const Koa = require('koa');

--- a/README.md
+++ b/README.md
@@ -86,10 +86,10 @@ console.log('curl -i http://localhost:3000/users -d "name=test"');
 ```
 
 ## Usage with unsupported text body type
-> for unsupported text body type for example `text/xml`. Raw and unparsed request body can be found at `ctx.request.body`, no `includeUnparsed` setting required
+For unsupported text body type, for example, `text/xml`, you can use the unparsed request body at `ctx.request.body`. For the text content type, the `includeUnparsed` setting is not required.
 
-index.js:
 ```js
+// xml-parse.js:
 const Koa = require('koa');
 const koaBody = require('koa-body');
 const convert = require('xml-js');
@@ -106,7 +106,7 @@ app.listen(3000);
 ```
 
 ```sh
-node index.js
+node xml-parse.js
 curl -i http://localhost:3000/users -H "Content-Type: text/xml" -d '<?xml version="1.0"?><catalog id="1"></catalog>'
 ```
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,41 @@ app.listen(3000);
 console.log('curl -i http://localhost:3000/users -d "name=test"');
 ```
 
+## Usage with unsupported text body type
+> for unsupported text body type for example `text/xml`. Raw and unparsed request body can be found at `ctx.request.body`, no `includeUnparsed` setting required
+
+index.js:
+```js
+const Koa = require('koa');
+const koaBody = require('koa-body');
+const convert = require('xml-js');
+
+const app = new Koa();
+
+app.use(koaBody());
+app.use(ctx => {
+  const obj = convert.xml2js(ctx.request.body)
+  ctx.body = `Request Body: ${JSON.stringify(obj)}`;
+});
+
+app.listen(3000);
+```
+
+```sh
+node index.js
+curl -i http://localhost:3000/users -H "Content-Type: text/xml" -d '<?xml version="1.0"?><catalog id="1"></catalog>'
+```
+
+Output:
+```text
+HTTP/1.1 200 OK
+Content-Type: text/plain; charset=utf-8
+Content-Length: 135
+Date: Tue, 09 Jun 2020 11:17:38 GMT
+Connection: keep-alive
+
+Request Body: {"declaration":{"attributes":{"version":"1.0"}},"elements":[{"type":"element","name":"catalog","attributes":{"id":"1"}}]}%
+```
 
 ## Options
 > Options available for `koa-body`. Four custom options, and others are from `raw-body` and `formidable`.

--- a/index.js
+++ b/index.js
@@ -91,7 +91,7 @@ function requestbody(opts) {
             queryString: opts.queryString,
             returnRawBody: opts.includeUnparsed
           });
-        } else if (opts.text && ctx.is('text')) {
+        } else if (opts.text && ctx.is('text/*')) {
           bodyPromise = buddy.text(ctx, {
             encoding: opts.encoding,
             limit: opts.textLimit,

--- a/index.js
+++ b/index.js
@@ -125,7 +125,7 @@ function requestbody(opts) {
           ctx.req.files = body.files;
         } else if (opts.includeUnparsed) {
           ctx.req.body = body.parsed || {};
-          if (! ctx.is('text')) {
+          if (! ctx.is('text/*')) {
             ctx.req.body[symbolUnparsed] = body.raw;
           }
         } else {

--- a/index.js
+++ b/index.js
@@ -138,7 +138,7 @@ function requestbody(opts) {
           ctx.request.files = body.files;
         } else if (opts.includeUnparsed) {
           ctx.request.body = body.parsed || {};
-          if (! ctx.is('text')) {
+          if (! ctx.is('text/*')) {
             ctx.request.body[symbolUnparsed] = body.raw;
           }
         } else {

--- a/test/index.js
+++ b/test/index.js
@@ -423,7 +423,7 @@ describe('koa-body', () => {
       });
   });
 
-  it('should recieve xml with `text` request bodies', (done) => {
+  it('should recieve raw XML with `text` request bodies', (done) => {
     app.use(koaBody({ text: true, includeUnparsed: true }));
     app.use(router.routes());
     const body = '<?xml version="1.0"?><catalog></catalog>';

--- a/test/index.js
+++ b/test/index.js
@@ -404,7 +404,7 @@ describe('koa-body', () => {
   /**
    * TEXT request body
    */
-  it('should recieve `text` request bodies',  (done) => {
+  it('should recieve `text` request bodies', (done) => {
     app.use(koaBody({ multipart: true }));
     app.use(router.routes());
 
@@ -423,18 +423,17 @@ describe('koa-body', () => {
       });
   });
 
-  it('should recieve any `text` request bodies',  (done) => {
+  it('should recieve xml with `text` request bodies', (done) => {
     app.use(koaBody({ text: true, includeUnparsed: true }));
     app.use(router.routes());
-    const type = 'text/xml';
-	const body = '<?xml version="1.0"?><catalog></catalog>';
+    const body = '<?xml version="1.0"?><catalog></catalog>';
 
     const echoRouterLayer = router.stack.filter(layer => layer.path === "/echo_body");
     const requestSpy = sinon.spy(echoRouterLayer[0].stack, '0');
 
     request(http.createServer(app.callback()))
       .post('/echo_body')
-      .type(type)
+      .type('text/xml')
       .send(body)
       .expect(200)
       .end( (err, res) => {


### PR DESCRIPTION
Adds support for all [text content types](https://www.iana.org/assignments/media-types/media-types.xhtml#text) by @ldarren.

Supersedes https://github.com/dlau/koa-body/pull/178 by @ldarren because I was unable to push changes to that repo.
FYI @wuteng606 @zzdhidden

Resolves #165 