### PR TITLE
fix: Add note to details on unparsed request

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Request Body: {"declaration":{"attributes":{"version":"1.0"}},"elements":[{"type
 - `text` **{Boolean}** Parse text bodies, such as XML, default `true`
 - `json` **{Boolean}** Parse JSON bodies, default `true`
 - `jsonStrict` **{Boolean}** Toggles co-body strict mode; if set to true - only parses arrays or objects, default `true`
-- `includeUnparsed` **{Boolean}** Toggles co-body returnRawBody option; if set to true, for form encodedand and JSON requests the raw, unparsed requesty body will be attached to `ctx.request.body` using a `Symbol`, default `false`
+- `includeUnparsed` **{Boolean}** Toggles co-body returnRawBody option; if set to true, for form encoded and JSON requests the raw, unparsed request body will be attached to `ctx.request.body` using a `Symbol` ([see details](https://github.com/dlau/koa-body#a-note-about-unparsed-request-bodies)), default `false`
 - `formidable` **{Object}** Options to pass to the formidable multipart parser
 - `onError` **{Function}** Custom error handle, if throw an error, you can customize the response - onError(error, context), default will throw
 - `strict` **{Boolean}** ***DEPRECATED*** If enabled, don't parse GET, HEAD, DELETE requests, default `true`

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Request Body: {"declaration":{"attributes":{"version":"1.0"}},"elements":[{"type
 - `text` **{Boolean}** Parse text bodies, such as XML, default `true`
 - `json` **{Boolean}** Parse JSON bodies, default `true`
 - `jsonStrict` **{Boolean}** Toggles co-body strict mode; if set to true - only parses arrays or objects, default `true`
-- `includeUnparsed` **{Boolean}** Toggles co-body returnRawBody option; if set to true, for form encoded and JSON requests the raw, unparsed request body will be attached to `ctx.request.body` using a `Symbol` ([see details](https://github.com/dlau/koa-body#a-note-about-unparsed-request-bodies)), default `false`
+- `includeUnparsed` **{Boolean}** Toggles co-body returnRawBody option; if set to true, for form encoded and JSON requests the raw, unparsed request body will be attached to `ctx.request.body` using a `Symbol` ([see details](#a-note-about-unparsed-request-bodies)), default `false`
 - `formidable` **{Object}** Options to pass to the formidable multipart parser
 - `onError` **{Function}** Custom error handle, if throw an error, you can customize the response - onError(error, context), default will throw
 - `strict` **{Boolean}** ***DEPRECATED*** If enabled, don't parse GET, HEAD, DELETE requests, default `true`


### PR DESCRIPTION
The "additional details" in the README were hard to spot and unconnected to the parameter the first time I looked, ended up going all the way back to the 2018 PR to find out how it worked. 😅 

Also fixed some spelling/grammar mistakes.